### PR TITLE
Bug/60

### DIFF
--- a/src/QC_SFTPClient.qpp
+++ b/src/QC_SFTPClient.qpp
@@ -104,7 +104,7 @@ SFTPClient::copy() {
     @code my hash $h = $sftpclient.info(); @endcode
 */
 hash SFTPClient::info() [flags=CONSTANT] {
-   return myself->sftp_info();
+   return myself->sftpInfo();
 }
 
 //! Returns the current path as a string or \c NOTHING if no path is set
@@ -114,7 +114,7 @@ hash SFTPClient::info() [flags=CONSTANT] {
     @code my *string $path = $sftpclient.path(); @endcode
 */
 *string SFTPClient::path() [flags=CONSTANT] {
-   return myself->sftp_path();
+   return myself->sftpPath();
 }
 
 //! Returns a hash of directory information; throws an exception if any errors occur
@@ -138,7 +138,7 @@ hash SFTPClient::info() [flags=CONSTANT] {
     @see SFTPClient::listFull()
 */
 hash SFTPClient::list(*string path, timeout timeout = 60s) [flags=RET_VALUE_ONLY] {
-   return myself->sftp_list(path ? path->getBuffer() : 0, (int)timeout, xsink);
+   return myself->sftpList(path ? path->getBuffer() : 0, (int)timeout, xsink);
 }
 
 //! Returns a list of directory information with detailed information for files, links, and directories; throws an exception if any errors occur
@@ -169,7 +169,7 @@ hash SFTPClient::list(*string path, timeout timeout = 60s) [flags=RET_VALUE_ONLY
     @since ssh2 0.9.8.1
 */
 list SFTPClient::listFull(*string path, timeout timeout = 60s) [flags=RET_VALUE_ONLY] {
-   return myself->sftp_list_full(path ? path->getBuffer() : 0, (int)timeout, xsink);
+   return myself->sftpListFull(path ? path->getBuffer() : 0, (int)timeout, xsink);
 }
 
 //! Returns a hash of information about a file or \c NOTHING if the file cannot be found
@@ -196,7 +196,7 @@ list SFTPClient::listFull(*string path, timeout timeout = 60s) [flags=RET_VALUE_
 */
 *hash SFTPClient::stat(string path, timeout timeout = 60s) [flags=RET_VALUE_ONLY] {
    LIBSSH2_SFTP_ATTRIBUTES attr;
-   int rc = myself->sftp_getAttributes(path->getBuffer(), &attr, (int)timeout, xsink);
+   int rc = myself->sftpGetAttributes(path->getBuffer(), &attr, (int)timeout, xsink);
    return rc < 0 ? 0 : attr2hash(attr);
 }
 
@@ -213,7 +213,7 @@ list SFTPClient::listFull(*string path, timeout timeout = 60s) [flags=RET_VALUE_
     @code $sftpclient.removeFile($path); @endcode
 */
 nothing SFTPClient::removeFile(string path, timeout timeout = 60s) {
-   myself->sftp_unlink(path->getBuffer(), (int)timeout, xsink);
+   myself->sftpUnlink(path->getBuffer(), (int)timeout, xsink);
 }
 
 //! Renames or moves a remote file; throws an exception if any errors occur
@@ -231,7 +231,7 @@ nothing SFTPClient::removeFile(string path, timeout timeout = 60s) {
     @code $sftpclient.name("file.txt", "file.txt.orig"); @endcode
 */
 nothing SFTPClient::rename(string old_name, string new_name, timeout timeout = 60s) {
-   myself->sftp_rename(old_name->getBuffer(), new_name->getBuffer(), (int)timeout, xsink);
+   myself->sftpRename(old_name->getBuffer(), new_name->getBuffer(), (int)timeout, xsink);
 }
 
 //! Changes the mode of a remote file or directory; sticky bits may not be set; throws an exception if any errors occur
@@ -255,7 +255,7 @@ nothing SFTPClient::chmod(string path, int mode, timeout timeout = 60s) {
       return 0;
    }
 
-  myself->sftp_chmod(path->getBuffer(), (int)mode, (int)timeout, xsink);
+  myself->sftpChmod(path->getBuffer(), (int)mode, (int)timeout, xsink);
 }
 
 //! Retrieves a remote file and returns it as a binary object; throws an exception if any errors occur
@@ -271,7 +271,7 @@ nothing SFTPClient::chmod(string path, int mode, timeout timeout = 60s) {
     @code my binary $b = $sftpclient.getFile("file.bin"); @endcode
 */
 binary SFTPClient::getFile(string path, timeout timeout = 60s) {
-   return myself->sftp_getFile(path->getBuffer(), (int)timeout, xsink);
+   return myself->sftpGetFile(path->getBuffer(), (int)timeout, xsink);
 }
 
 //! Retrieves a remote file and returns it as a string; throws an exception if any errors occur
@@ -289,7 +289,7 @@ binary SFTPClient::getFile(string path, timeout timeout = 60s) {
 */
 string SFTPClient::getTextFile(string path, timeout timeout = 60s, *string encoding) {
    const QoreEncoding *qe = encoding ? QEM.findCreate(encoding) : QCS_DEFAULT;
-   return myself->sftp_getTextFile(path->getBuffer(), (int)timeout, qe, xsink);
+   return myself->sftpGetTextFile(path->getBuffer(), (int)timeout, qe, xsink);
 }
 
 //! Saves a file on the remote server from a binary argument and returns the number of bytes sent; throws an exception if any errors occur
@@ -310,7 +310,7 @@ string SFTPClient::getTextFile(string path, timeout timeout = 60s, *string encod
 */
 int SFTPClient::putFile(binary bin, string path, int mode = 0644, timeout timeout = 60s) {
    // transfer the file
-   return myself->sftp_putFile((const char *)bin->getPtr(), bin->size(), path->getBuffer(), (int)mode, (int)timeout, xsink);
+   return myself->sftpPutFile((const char *)bin->getPtr(), bin->size(), path->getBuffer(), (int)mode, (int)timeout, xsink);
 }
 
 //! Saves a file on the remote server from a string argument and returns the number of bytes sent; throws an exception if any errors occur
@@ -331,7 +331,7 @@ int SFTPClient::putFile(binary bin, string path, int mode = 0644, timeout timeou
 */
 int SFTPClient::putFile(string data, string path, int mode = 0644, timeout timeout = 60s) {
    // transfer the file
-   return myself->sftp_putFile(data->getBuffer(), data->strlen(), path->getBuffer(), (int)mode, (int)timeout, xsink);
+   return myself->sftpPutFile(data->getBuffer(), data->strlen(), path->getBuffer(), (int)mode, (int)timeout, xsink);
 }
 
 //! Makes a directory on the remote server; throws an exception if any errors occur
@@ -349,7 +349,7 @@ int SFTPClient::putFile(string data, string path, int mode = 0644, timeout timeo
     @code $sftpclient.mkdir($path, 0700); @endcode
 */
 nothing SFTPClient::mkdir(string path, int mode = 0755, timeout timeout = 60s) {
-   myself->sftp_mkdir(path->getBuffer(), (int)mode, (int)timeout, xsink);
+   myself->sftpMkdir(path->getBuffer(), (int)mode, (int)timeout, xsink);
 }
 
 //! Removes a directory on the remote server; throws an exception if any errors occur
@@ -366,7 +366,7 @@ nothing SFTPClient::mkdir(string path, int mode = 0755, timeout timeout = 60s) {
     @code $sftpclient.rmdir($path); @endcode
 */
 nothing SFTPClient::rmdir(string path, timeout timeout = 60s) {
-   myself->sftp_rmdir(path->getBuffer(), (int)timeout, xsink);
+   myself->sftpRmdir(path->getBuffer(), (int)timeout, xsink);
 }
 
 //! Changes the directory on the remote server and returns the new directory; throws an exception if any errors occur
@@ -382,5 +382,5 @@ nothing SFTPClient::rmdir(string path, timeout timeout = 60s) {
     @code $sftpclient.chdir($path); @endcode
 */
 string SFTPClient::chdir(string path, timeout timeout = 60s) {
-   return myself->sftp_chdir(path->getBuffer(), (int)timeout, xsink);
+   return myself->sftpChdir(path->getBuffer(), (int)timeout, xsink);
 }

--- a/src/QC_SSH2Base.qpp
+++ b/src/QC_SSH2Base.qpp
@@ -132,7 +132,7 @@ nothing SSH2Base::setKeys(string priv_key, *string pub_key) [dom=FILESYSTEM] {
     @since ssh2 0.9.8.1
  */
 bool SSH2Base::connected() [flags=CONSTANT] {
-  return myself->ssh_connected();
+  return myself->sshConnected();
 }
 
 //! Removes any warning @ref Qore::Thread::Queue "Queue" object from the Socket

--- a/src/QC_SSH2Client.qpp
+++ b/src/QC_SSH2Client.qpp
@@ -85,7 +85,7 @@ SSH2Client::copy() {
     @code my hash $h = $ssh2client.info(); @endcode
  */
 hash SSH2Client::info() [flags=CONSTANT] {
-   return c->ssh_info();
+   return c->sshInfo();
 }
 
 //! Opens a login session and returns a SSH2Channel object for the session

--- a/src/SFTPClient.cpp
+++ b/src/SFTPClient.cpp
@@ -191,6 +191,7 @@ int SFTPClient::sftpConnected() {
 }
 
 int SFTPClient::disconnectUnlocked(bool force, int timeout_ms, AbstractDisconnectionHelper* adh, ExceptionSink* xsink) {
+   //printd(5, "SFTPClient::disconnectUnlocked() force: %d timeout_ms: %d adh: %p xsink: %p\n", force, timeout_ms, adh, xsink);
    int rc;
 
    // disconnect dependent opbjects first
@@ -813,7 +814,7 @@ BinaryNode* SFTPClient::sftpGetFile(const char* file, int timeout_ms, ExceptionS
       qh.err("libssh2_sftp_stat(%s) returned an error", fname.c_str());
       return 0;
    }
-   //printd(0, "SFTPClient::sftp_getFile() permissions: %lo\n", attrs.permissions);
+   //printd(5, "SFTPClient::sftpGetFile() permissions: %lo\n", attrs.permissions);
    size_t fsize = attrs.filesize;
 
    {

--- a/src/SFTPClient.h
+++ b/src/SFTPClient.h
@@ -47,7 +47,7 @@ DLLLOCAL extern qore_classid_t CID_SFTP_CLIENT;
 
 class SFTPClient;
 
-class QSftpHelper {
+class QSftpHelper : public AbstractDisconnectionHelper {
 private:
    LIBSSH2_SFTP_HANDLE* sftp_handle;
    SFTPClient* client;
@@ -92,6 +92,11 @@ public:
    }
 
    DLLLOCAL void err(const char* fmt, ...);
+
+   DLLLOCAL virtual void preDisconnect() {
+      if (sftp_handle)
+         closeIntern();
+   }
 };
 
 class SFTPClient : public SSH2Client {
@@ -102,14 +107,14 @@ protected:
    DLLLOCAL virtual ~SFTPClient();
    DLLLOCAL virtual void deref(ExceptionSink*);
 
-   DLLLOCAL int sftp_connected_unlocked();
-   DLLLOCAL QoreStringNode *sftp_path_unlocked();
-   DLLLOCAL int sftp_connect_unlocked(int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL int sftpConnectedUnlocked();
+   DLLLOCAL QoreStringNode *sftpPathUnlocked();
+   DLLLOCAL int sftpConnectUnlocked(int timeout_ms, ExceptionSink* xsink);
 
-   DLLLOCAL void do_session_err_unlocked(ExceptionSink* xsink, QoreStringNode* desc);
-   DLLLOCAL void do_shutdown(int timeout_ms = DEFAULT_TIMEOUT_MS, ExceptionSink* xsink = 0);
+   DLLLOCAL void doSessionErrUnlocked(ExceptionSink* xsink, QoreStringNode* desc);
+   DLLLOCAL void doShutdown(int timeout_ms = DEFAULT_TIMEOUT_MS, ExceptionSink* xsink = 0);
 
-   DLLLOCAL virtual int disconnect_unlocked(bool force, int timeout_ms = DEFAULT_TIMEOUT_MS, ExceptionSink* xsink = 0);
+   DLLLOCAL virtual int disconnectUnlocked(bool force, int timeout_ms = DEFAULT_TIMEOUT_MS, AbstractDisconnectionHelper* adh = 0, ExceptionSink* xsink = 0);
    
 public:
    // session props
@@ -121,31 +126,31 @@ public:
    DLLLOCAL SFTPClient(QoreURL& url, const uint32_t = 0);
 
    DLLLOCAL virtual int connect(int timeout_ms, ExceptionSink* xsink) {
-      return sftp_connect(timeout_ms, xsink);
+      return sftpConnect(timeout_ms, xsink);
    }
    
-   DLLLOCAL int sftp_connect(int timeout_ms, ExceptionSink* xsink = 0);
+   DLLLOCAL int sftpConnect(int timeout_ms, ExceptionSink* xsink = 0);
 
-   DLLLOCAL int sftp_connected();
+   DLLLOCAL int sftpConnected();
 
-   //DLLLOCAL QoreStringNode *sftp_path(ExceptionSink* xsink);
-   DLLLOCAL QoreStringNode *sftp_path();
-   DLLLOCAL QoreStringNode *sftp_chdir(const char* nwd, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL QoreHashNode *sftp_list(const char* path, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL QoreListNode *sftp_list_full(const char* path, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL int sftp_mkdir(const char* dir, const int mode, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL int sftp_rmdir(const char* dir, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL int sftp_rename(const char* from, const char* to, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL int sftp_unlink(const char* file, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL int sftp_chmod(const char* file, const int mode, int timeout_ms, ExceptionSink* xsink);
+   //DLLLOCAL QoreStringNode *sftpPath(ExceptionSink* xsink);
+   DLLLOCAL QoreStringNode *sftpPath();
+   DLLLOCAL QoreStringNode *sftpChdir(const char* nwd, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL QoreHashNode *sftpList(const char* path, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL QoreListNode *sftpListFull(const char* path, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL int sftpMkdir(const char* dir, const int mode, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL int sftpRmdir(const char* dir, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL int sftpRename(const char* from, const char* to, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL int sftpUnlink(const char* file, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL int sftpChmod(const char* file, const int mode, int timeout_ms, ExceptionSink* xsink);
 
-   DLLLOCAL BinaryNode *sftp_getFile(const char* file, int timeout_ms, ExceptionSink* xsink);
-   DLLLOCAL QoreStringNode *sftp_getTextFile(const char* file, int timeout_ms, const QoreEncoding *encoding, ExceptionSink* xsink);
-   DLLLOCAL qore_size_t sftp_putFile(const char* data, qore_size_t len, const char* fname, int mode, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL BinaryNode *sftpGetFile(const char* file, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL QoreStringNode *sftpGetTextFile(const char* file, int timeout_ms, const QoreEncoding *encoding, ExceptionSink* xsink);
+   DLLLOCAL qore_size_t sftpPutFile(const char* data, qore_size_t len, const char* fname, int mode, int timeout_ms, ExceptionSink* xsink);
 
-   DLLLOCAL int sftp_getAttributes(const char* fname, LIBSSH2_SFTP_ATTRIBUTES *attrs, int timeout_ms, ExceptionSink* xsink);
+   DLLLOCAL int sftpGetAttributes(const char* fname, LIBSSH2_SFTP_ATTRIBUTES *attrs, int timeout_ms, ExceptionSink* xsink);
 
-   DLLLOCAL QoreHashNode *sftp_info();
+   DLLLOCAL QoreHashNode *sftpInfo();
 };
 
 // maybe this should go to ssh2-module.h?

--- a/src/SSH2Channel.cpp
+++ b/src/SSH2Channel.cpp
@@ -32,8 +32,8 @@ void SSH2Channel::destructor() {
    // close channel and deregister from parent
    AutoLocker al(parent->m);
    if (channel) {
-      parent->channel_deleted_unlocked(this);
-      close_unlocked();
+      parent->channelDeletedUnlocked(this);
+      closeUnlocked();
    }
 }
 
@@ -48,12 +48,12 @@ int SSH2Channel::setenv(const char *name, const char *value, int timeout_ms, Exc
    while (true) {
       rc = libssh2_channel_setenv(channel, (char *)name, value);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SETENV-ERROR", "SSH2Channel::setenv", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SETENV-ERROR", "SSH2Channel::setenv", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -73,12 +73,12 @@ int SSH2Channel::requestPty(ExceptionSink *xsink, const QoreString &term, const 
    while (true) {
       rc = libssh2_channel_request_pty_ex(channel, term.getBuffer(), term.strlen(), modes.strlen() ? modes.getBuffer() : 0, modes.strlen(), width, height, width_px, height_px);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-REQUESTPTY-ERROR", "SSH2Channel::requestPty", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-REQUESTPTY-ERROR", "SSH2Channel::requestPty", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -96,12 +96,12 @@ int SSH2Channel::shell(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_shell(channel);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SHELL-ERROR", "SSH2Channel::shell", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SHELL-ERROR", "SSH2Channel::shell", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -127,12 +127,12 @@ int SSH2Channel::waitEof(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_wait_eof(channel);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-WAITEOF-ERROR", "SSH2Channel::waitEof", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-WAITEOF-ERROR", "SSH2Channel::waitEof", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -150,12 +150,12 @@ int SSH2Channel::sendEof(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_send_eof(channel);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SENDEOF-ERROR", "SSH2Channel::sendEof", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SENDEOF-ERROR", "SSH2Channel::sendEof", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -174,12 +174,12 @@ int SSH2Channel::exec(const char *command, int timeout_ms, ExceptionSink *xsink)
       rc = libssh2_channel_exec(channel, command);
       //printd(5, "SSH2Channel::exec() cmd=%s rc=%d\n", command, rc);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXEC-ERROR", "SSH2Channel::exec", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXEC-ERROR", "SSH2Channel::exec", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -198,12 +198,12 @@ int SSH2Channel::subsystem(const char *command, int timeout_ms, ExceptionSink *x
       rc = libssh2_channel_subsystem(channel, command);
       //printd(5, "SSH2Channel::subsystem() cmd=%s rc=%d\n", command, rc);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SUBSYSTEM-ERROR", "SSH2Channel::subsystem", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-SUBSYSTEM-ERROR", "SSH2Channel::subsystem", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -234,7 +234,7 @@ QoreStringNode *SSH2Channel::read(ExceptionSink *xsink, int stream_id, int timeo
       }
       else if (rc == LIBSSH2_ERROR_EAGAIN && !str->strlen() && first) {
 	 first = false;
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-READ-ERROR", "SSH2Channel::read", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-READ-ERROR", "SSH2Channel::read", timeout_ms)))
 	    return 0;
 	 goto loop0;
       }
@@ -242,7 +242,7 @@ QoreStringNode *SSH2Channel::read(ExceptionSink *xsink, int stream_id, int timeo
    while (rc > 0);
 
    if (rc < 0 && rc != LIBSSH2_ERROR_EAGAIN) {
-      parent->do_session_err_unlocked(xsink);
+      parent->doSessionErrUnlocked(xsink);
       return 0;
    }
 
@@ -279,7 +279,7 @@ QoreStringNode *SSH2Channel::read(qore_size_t size, int stream_id, int timeout_m
       }
 
       if (!rc || rc == LIBSSH2_ERROR_EAGAIN) {
-	 rc = parent->waitsocket_unlocked(timeout_ms);
+	 rc = parent->waitSocketUnlocked(timeout_ms);
 	 if (!rc) {
 	    xsink->raiseException(SSH2CHANNEL_TIMEOUT, "read timeout after %dms, read %lu byte%s of %lu requested", timeout_ms, b_read, b_read == 1 ? "" : "s", size);
 	    return 0;
@@ -292,7 +292,7 @@ QoreStringNode *SSH2Channel::read(qore_size_t size, int stream_id, int timeout_m
    }
 
    if (rc < 0 && rc != LIBSSH2_ERROR_EAGAIN) {
-      parent->do_session_err_unlocked(xsink);
+      parent->doSessionErrUnlocked(xsink);
       return 0;
    }
 
@@ -321,7 +321,7 @@ BinaryNode *SSH2Channel::readBinary(ExceptionSink *xsink, int stream_id, int tim
       }
       else if (rc == LIBSSH2_ERROR_EAGAIN && !bin->size() && first) {
 	 first = false;
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-READBINARY-ERROR", "SSH2Channel::readBinary", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-READBINARY-ERROR", "SSH2Channel::readBinary", timeout_ms)))
 	    return 0;
 	 goto loop0;
       }
@@ -329,7 +329,7 @@ BinaryNode *SSH2Channel::readBinary(ExceptionSink *xsink, int stream_id, int tim
    while (rc > 0);
 
    if (rc < 0 && rc != LIBSSH2_ERROR_EAGAIN) {
-      parent->do_session_err_unlocked(xsink);
+      parent->doSessionErrUnlocked(xsink);
       return 0;
    }
 
@@ -366,7 +366,7 @@ BinaryNode *SSH2Channel::readBinary(qore_size_t size, int stream_id, int timeout
       }
 
       if (!rc || rc == LIBSSH2_ERROR_EAGAIN) {
-	 rc = parent->waitsocket_unlocked(timeout_ms);
+	 rc = parent->waitSocketUnlocked(timeout_ms);
 	 if (!rc) {
 	    xsink->raiseException(SSH2CHANNEL_TIMEOUT, "read timeout after %dms reading %lld byte%s of %lld requested", timeout_ms, b_read, b_read == 1 ? "" : "s", size);
 	    return 0;
@@ -379,7 +379,7 @@ BinaryNode *SSH2Channel::readBinary(qore_size_t size, int stream_id, int timeout
    }
 
    if (rc < 0 && rc != LIBSSH2_ERROR_EAGAIN) {
-      parent->do_session_err_unlocked(xsink);
+      parent->doSessionErrUnlocked(xsink);
       return 0;
    }
 
@@ -405,7 +405,7 @@ qore_size_t SSH2Channel::write(ExceptionSink *xsink, const void *buf, qore_size_
 	 if (rc && rc != LIBSSH2_ERROR_EAGAIN)
 	    break;
 
-	 rc = parent->waitsocket_unlocked(timeout_ms);
+	 rc = parent->waitSocketUnlocked(timeout_ms);
 	 if (!rc) {
 	    xsink->raiseException(SSH2CHANNEL_TIMEOUT, "write timeout after %dms writing %lu byte%s of %lu", timeout_ms, b_sent, b_sent == 1 ? "" : "s", buflen);
 	    return -1;
@@ -417,7 +417,7 @@ qore_size_t SSH2Channel::write(ExceptionSink *xsink, const void *buf, qore_size_
       }
 
       if (rc < 0)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
 
       b_sent += rc;
       if (b_sent >= buflen)
@@ -438,12 +438,12 @@ int SSH2Channel::close(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_close(channel);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-CLOSE-ERROR", "SSH2Channel::close", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-CLOSE-ERROR", "SSH2Channel::close", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc < 0)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -461,12 +461,12 @@ int SSH2Channel::waitClosed(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_wait_closed(channel);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-WAITCLOSED-ERROR", "SSH2Channel::waitClosed", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-WAITCLOSED-ERROR", "SSH2Channel::waitClosed", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc < 0)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
 
@@ -493,12 +493,12 @@ int SSH2Channel::requestX11Forwarding(ExceptionSink *xsink, int screen_number, b
    while (true) {
       rc = libssh2_channel_x11_req_ex(channel, (int)single_connection, auth_proto, auth_cookie, screen_number);
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-REQUESTX11FORWARDING-ERROR", "SSH2Channel::requestX11Forwarding", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-REQUESTX11FORWARDING-ERROR", "SSH2Channel::requestX11Forwarding", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc < 0)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
    return rc;
@@ -513,12 +513,12 @@ int SSH2Channel::extendedDataNormal(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_handle_extended_data2(channel, LIBSSH2_CHANNEL_EXTENDED_DATA_NORMAL); 
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXTENDEDDATANORMAL-ERROR", "SSH2Channel::extendedDataNormal", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXTENDEDDATANORMAL-ERROR", "SSH2Channel::extendedDataNormal", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc < 0)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
    return rc;
@@ -533,12 +533,12 @@ int SSH2Channel::extendedDataMerge(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_handle_extended_data2(channel, LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE); 
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXTENDEDDATAMERGE-ERROR", "SSH2Channel::extendedDataMerge", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXTENDEDDATAMERGE-ERROR", "SSH2Channel::extendedDataMerge", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc < 0)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
    return rc;
@@ -553,12 +553,12 @@ int SSH2Channel::extendedDataIgnore(ExceptionSink *xsink, int timeout_ms) {
    while (true) {
       rc = libssh2_channel_handle_extended_data2(channel, LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE); 
       if (rc == LIBSSH2_ERROR_EAGAIN) {
-	 if ((rc = parent->waitsocket_unlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXTENDEDDATAIGNORE-ERROR", "SSH2Channel::extendedDataIgnore", timeout_ms)))
+	 if ((rc = parent->waitSocketUnlocked(xsink, SSH2CHANNEL_TIMEOUT, "SSH2CHANNEL-EXTENDEDDATAIGNORE-ERROR", "SSH2Channel::extendedDataIgnore", timeout_ms)))
 	    break;
 	 continue;
       }
       if (rc < 0)
-	 parent->do_session_err_unlocked(xsink);
+	 parent->doSessionErrUnlocked(xsink);
       break;
    }
    return rc;

--- a/src/SSH2Channel.h
+++ b/src/SSH2Channel.h
@@ -45,7 +45,7 @@ protected:
    SSH2Client *parent;
    const QoreEncoding *enc;
 
-   void close_unlocked() {
+   void closeUnlocked() {
       libssh2_channel_free(channel);
       channel = 0;
    }


### PR DESCRIPTION
this appears to fix the crashes in the SFTPClient class related to disconnections during SFTP operations.

I simulated a disconnection that results in a crash - the crash was due to the SSH2Client base class disconnection and then trying to close the SFTP handle which requires a connection.

With the fix the simulation did not crash but correctly closed the handle before the connection was disconnected, reporting a Qore-language exception back to the caller.