### PR TITLE
refs #313 use the qore binary instead of qr since qr will be removed …

### DIFF
--- a/test/SFTPClient.qtest
+++ b/test/SFTPClient.qtest
@@ -1,9 +1,10 @@
-#!/usr/bin/env qr
+#!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
 %new-style
 %require-types
 %require-our
+%strict-args
 
 %requires qore >= 0.8.12
 %requires ssh2 >= 1.0


### PR DESCRIPTION
…from qore until %strict-types has been implemented
