### PR TITLE
refs #739 allow for the SftpPoller class to be destroyed normally whe…

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -2,8 +2,6 @@
 version 1.0
 ***********
 
-* SftpPoller reexports ssh2
-* SftpPoller sleeps for poll_interval even the processed files are not deleted.
 * fixed crashing bugs handling errors and handle scope in the SFTPClient class
 * added the SftpPoller user module
 * force socket disconnect in case of a timeout error when trying to close a

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -102,8 +102,6 @@ stdout.printf("exit status: %d\n", $chan.getExitStatus());@endcode
     @section ssh2releasenotes Release Notes
 
     @subsection ssh2v10 Version 1.0
-    - <a href="../../SftpPoller/html/index.html">SftpPoller</a> reexports ssh2
-    - <a href="../../SftpPoller/html/index.html">SftpPoller</a> sleeps for \a poll_interval even when matched files are not deleted
     - fixed crashing bugs handling errors and handle scope in the @ref Qore::SSH2::SFTPClient "SFTPClient" class
     - added the <a href="../../SftpPoller/html/index.html">SftpPoller</a> user module
     - force socket disconnect in case of a timeout error when trying to close a file descriptor

--- a/qlib/SftpPoller.qm
+++ b/qlib/SftpPoller.qm
@@ -603,7 +603,7 @@ public namespace SftpPoller {
             @see stopNoWait()
         */
         stop() {
-            if (gettid() == tid)
+            if (gettid() == tid && sc.getCount())
                 throw "THREAD-ERROR", sprintf("cannot call SftpPoller::stop() from the event thread (%d)", tid);
             m.lock();
             on_exit m.unlock();
@@ -691,7 +691,8 @@ public namespace SftpPoller {
 
         #! starts the polling operation
         synchronized private run() {
-            on_exit sc.dec();
+            on_exit
+                sc.dec();
 
             while (runflag) {
                 try {


### PR DESCRIPTION
…n the polling thread holds the last reference to the object
