### PR TITLE
refs #765 a parameter error in SFTPClient disconnection when there we…

### DIFF
--- a/src/SFTPClient.cpp
+++ b/src/SFTPClient.cpp
@@ -1345,7 +1345,7 @@ int QSftpHelper::closeIntern() {
    // close the handle
    int rc;
    while ((rc = libssh2_sftp_close_handle(sftp_handle)) == LIBSSH2_ERROR_EAGAIN) {
-      if (client->waitSocketUnlocked(xsink, SFTPCLIENT_TIMEOUT, errstr, meth, timeout_ms)) {
+      if (client->waitSocketUnlocked(xsink, SFTPCLIENT_TIMEOUT, errstr, meth, timeout_ms, true)) {
          // note: memory leak here! we cannot close the handle due to the timeout
          printd(0, "QSftpHelper::closeIntern() session %p: cannot close remote file descriptor, forcing session disconnect; leaking descriptor\n", client->ssh_session);
          client->disconnectUnlocked(true, 10, 0, xsink);


### PR DESCRIPTION
…re socket I/O errors caused a virtual method call to be made on NULL which caused a crash (and often stack corruption which made it difficult to debug)

this is a new bug in unreleased functionality and does not affect the 1.0-2014-07-28 branch
