### PR TITLE
refs #798 removed the "synchronized" keyword from the SftpPoller::run…

### DIFF
--- a/qlib/SftpPoller.qm
+++ b/qlib/SftpPoller.qm
@@ -699,7 +699,7 @@ public namespace SftpPoller {
         }
 
         #! starts the polling operation
-        synchronized private run() {
+        private run() {
             on_exit
                 sc.dec();
 


### PR DESCRIPTION
…() method so that multiple threads can implement pollers
