### PR TITLE
refs qore/qorelanguage#1557 added new option 'skip_file_content_retri…

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,4 +1,10 @@
 ***********
+version 1.1
+***********
+
+please see doxygen-generated release notes
+
+***********
 version 1.0
 ***********
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 
 # AC_PREREQ(2.59)
-AC_INIT([qore-ssh2-module], [1.0],
+AC_INIT([qore-ssh2-module], [1.1],
         [David Nichols <david(a)qore(dot)org>, Wolfgang Ritzinger <aargon(a)rat(dot)at>],
         [qore-ssh2-module])
 AM_INIT_AUTOMAKE([no-dist-gzip dist-bzip2])

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -101,7 +101,7 @@ stdout.printf("exit status: %d\n", $chan.getExitStatus());@endcode
 
     @section ssh2releasenotes Release Notes
 
-    @subsection ssh2v10 Version 1.1
+    @subsection ssh2v11 Version 1.1
     - argument error in SFTPClient disconnection with socket errors causes a crash (<a href="https://github.com/qorelanguage/qore/issues/714">issue 765</a>)
     - infinite loop in SftpPoller polling when PO_NO_PROCESS_CONTROL is not set and no sleep option is given (<a href="https://github.com/qorelanguage/qore/issues/773">issue 773</a>)
     - implement support for additional directories in SftpPoller (<a href="https://github.com/qorelanguage/qore/issues/753">issue 753</a>)

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -101,6 +101,16 @@ stdout.printf("exit status: %d\n", $chan.getExitStatus());@endcode
 
     @section ssh2releasenotes Release Notes
 
+    @subsection ssh2v10 Version 1.1
+    - argument error in SFTPClient disconnection with socket errors causes a crash (<a href="https://github.com/qorelanguage/qore/issues/714">issue 765</a>)
+    - infinite loop in SftpPoller polling when PO_NO_PROCESS_CONTROL is not set and no sleep option is given (<a href="https://github.com/qorelanguage/qore/issues/773">issue 773</a>)
+    - implement support for additional directories in SftpPoller (<a href="https://github.com/qorelanguage/qore/issues/753">issue 753</a>)
+    - SftpPoller::run() cannot be synchronized (<a href="https://github.com/qorelanguage/qore/issues/798">issue 798</a>)
+    - compile fixes for Solaris 10 g++ (<a href="https://github.com/qorelanguage/qore/issues/861">issue 861</a>)
+    - add contructor option to SftpPoller for checking if polled directories are writable (<a href="https://github.com/qorelanguage/qore/issues/888">issue 888</a>)
+    - crash in SFTPClient (<a href="https://github.com/qorelanguage/qore/issues/1040">issue 1040</a>)
+    - streaming from SFTP server impossible without user re-implementing SftpPoller methods (<a href="https://github.com/qorelanguage/qore/issues/1557">issue 1557</a>)
+
     @subsection ssh2v10 Version 1.0
     - fixed crashing bugs handling errors and handle scope in the @ref Qore::SSH2::SFTPClient "SFTPClient" class
     - added the <a href="../../SftpPoller/html/index.html">SftpPoller</a> user module

--- a/qlib/SftpPoller.qm
+++ b/qlib/SftpPoller.qm
@@ -157,6 +157,7 @@ public namespace SftpPoller {
 %ifndef PO_NO_THREAD_CONTROL
                 "start_thread",
 %endif
+                "skip_file_content_retrieval",
                 );
 
             #! all keys
@@ -256,6 +257,9 @@ public namespace SftpPoller {
 
             #! name of check writable file
             string check_file;
+
+            #! whether or not to skip the file content retrieval in runOnce()
+            *bool skip_file_content_retrieval;
         }
 
         #! creates the SftpPoller object from the @ref Qore::SSH2::SFTPClient "SFTPClient" argument and configuration hash argument passed
@@ -365,6 +369,7 @@ public namespace SftpPoller {
             - \c sleep: (required when imported into a context where @ref Qore::PO_NO_PROCESS_CONTROL is set) a @ref closure "closure" or @ref call_reference "call reference" to use instead of @ref Qore::sleep() (if not set then @ref Qore::sleep() will be used)
             - \c writable: check if path(s) is/are writable  (default: False see also the \c "check_file" option)
             - \c check_file: name of a check file. The file will be created and deleted in the path to test if path is writable. If the file alrady exists, it will be deleted. (default: \c "qore-sftp-check-file")
+            - \c skip_file_content_retrieval: if True then @ref SftpPoller::SftpPoller::singleFileEvent and @ref SftpPoller::SftpPoller::postSingleFileEvent methods won't get 'data' member of the input hash, i.e. the file content won't be read by the SftpPoller class, opening a space for child classes to implement their own file retrieval in @ref SftpPoller::SftpPoller::singleFileEvent or @ref SftpPoller::SftpPoller::postSingleFileEvent (default: False)
 
             @throw SFTPPOLLER-CONSTRUCTOR-ERROR missing required key, invalid port or poll_interval given
             @throw SFTPCLIENT-PARAMETER-ERROR empty hostname passed
@@ -707,13 +712,18 @@ public namespace SftpPoller {
 
                     if (fileEvent(files)) {
                         foreach hash fh in (files) {
-                            # transfer file from server
-                            logInfo("%y: retrieving %s file data", fh.name, binary ? "binary" : "text");
-                            date t1 = now_us();
+                            if (skip_file_content_retrieval) {
+                                logInfo("%y: skipping retrieval of file data based on the poller configuration", fh.name);
+                            }
+                            else {
+                                # transfer file from server
+                                logInfo("%y: retrieving %s file data", fh.name, binary ? "binary" : "text");
+                                date t1 = now_us();
 
-                            get_files = True;
-                            fh.data = binary ? getFile(fh.name) : getTextFile(fh.name);
-                            logInfo("%y: retrieved %d bytes in %y", fh.name, fh.data.size(), now_us() - t1);
+                                get_files = True;
+                                fh.data = binary ? getFile(fh.name) : getTextFile(fh.name);
+                                logInfo("%y: retrieved %d bytes in %y", fh.name, fh.data.size(), now_us() - t1);
+                            }
 
                             # make sure any errors after this point cause the polling operation to stop
                             get_files = False;
@@ -787,7 +797,7 @@ public namespace SftpPoller {
             - \c mtime: the last modified date/time of the file
             - \c type: the type of file; one of: \c "REGULAR", \c "DIRECTORY", \c "SYMBOLIC-LINK", \c "BLOCK-DEVICE", \c "CHARACTER-DEVICE", \c "FIFO", \c "SYMBOLIC-LINK", \c "SOCKET", or \c "UNKNOWN"
             - \c perm: a string giving UNIX-style permissions for the file (ex: "-rwxr-xr-x")
-            - \c data: the file's data; this will be a string unless the \a "binary" option is set to @ref Qore::True "True", in which case this key is assigned to the files binary data
+            - \c data: the file's data; this will be a string unless the \a "binary" option is set to @ref Qore::True "True", in which case this key is assigned to the files binary data; this hash key is only present if \c skip_file_content_retrieval was @ref Qore::False "False" in the @ref SftpPoller::SftpPoller::constructor options
             - \c filepath: the remote filepath relative to SFTP root directory
         */
         abstract singleFileEvent(hash fih);
@@ -807,7 +817,7 @@ public namespace SftpPoller {
             - \c mtime: the last modified date/time of the file
             - \c type: the type of file; one of: \c "REGULAR", \c "DIRECTORY", \c "SYMBOLIC-LINK", \c "BLOCK-DEVICE", \c "CHARACTER-DEVICE", \c "FIFO", \c "SYMBOLIC-LINK", \c "SOCKET", or \c "UNKNOWN"
             - \c perm: a string giving UNIX-style permissions for the file (ex: "-rwxr-xr-x")
-            - \c data: the file's data; this will be a string unless the \a "binary" option is set to @ref Qore::True "True", in which case this key is assigned to the files binary data
+            - \c data: the file's data; this will be a string unless the \a "binary" option is set to @ref Qore::True "True", in which case this key is assigned to the files binary data; this hash key is only present if \c skip_file_content_retrieval was @ref Qore::False "False" in the @ref SftpPoller::SftpPoller::constructor options
             - \c filepath: the remote filepath relative to SFTP root directory
         */
         abstract postSingleFileEvent(hash fih);

--- a/qlib/SftpPoller.qm
+++ b/qlib/SftpPoller.qm
@@ -32,7 +32,7 @@
 %new-style
 
 module SftpPoller {
-    version = "1.0";
+    version = "1.1";
     desc = "SftpPoller module";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -40,6 +40,7 @@ module SftpPoller {
 }
 
 /*  Version History
+    * 2017-02-02 v1.1: Pavel Kveton <pavel.kveton@qoretechnologies.org>
     * 2014-03-01 v1.0: David Nichols <david@qore.org>: initial version
 */
 
@@ -369,7 +370,7 @@ public namespace SftpPoller {
             - \c sleep: (required when imported into a context where @ref Qore::PO_NO_PROCESS_CONTROL is set) a @ref closure "closure" or @ref call_reference "call reference" to use instead of @ref Qore::sleep() (if not set then @ref Qore::sleep() will be used)
             - \c writable: check if path(s) is/are writable  (default: False see also the \c "check_file" option)
             - \c check_file: name of a check file. The file will be created and deleted in the path to test if path is writable. If the file alrady exists, it will be deleted. (default: \c "qore-sftp-check-file")
-            - \c skip_file_content_retrieval: if True then @ref SftpPoller::SftpPoller::singleFileEvent and @ref SftpPoller::SftpPoller::postSingleFileEvent methods won't get 'data' member of the input hash, i.e. the file content won't be read by the SftpPoller class, opening a space for child classes to implement their own file retrieval in @ref SftpPoller::SftpPoller::singleFileEvent or @ref SftpPoller::SftpPoller::postSingleFileEvent (default: False)
+            - \c skip_file_content_retrieval: if True then @ref SftpPoller::SftpPoller::singleFileEvent and @ref SftpPoller::SftpPoller::postSingleFileEvent methods won't get 'data' member of the input hash, i.e. the file content won't be read by the SftpPoller class, opening a space for child classes to implement their own file retrieval in @ref SftpPoller::SftpPoller::singleFileEvent or @ref SftpPoller::SftpPoller::postSingleFileEvent (default: False); (since ssh2 1.1)
 
             @throw SFTPPOLLER-CONSTRUCTOR-ERROR missing required key, invalid port or poll_interval given
             @throw SFTPCLIENT-PARAMETER-ERROR empty hostname passed

--- a/qore-ssh2-module.spec
+++ b/qore-ssh2-module.spec
@@ -1,4 +1,4 @@
-%define mod_ver 1.0
+%define mod_ver 1.1
 
 %{?_datarootdir: %global mydatarootdir %_datarootdir}
 %{!?_datarootdir: %global mydatarootdir /usr/share}
@@ -102,6 +102,9 @@ This RPM provides API documentation, test and example programs
 %doc docs/ssh2/ docs/SftpPoller/ test/
 
 %changelog
+* Thu Feb 2 2017 Pavel Kvetons <pavel.kveton@qoretechnologies.org> - 1.1
+- updated to version 1.1
+
 * Sat Dec 7 2013 David Nichols <david@qore.org> - 1.0
 - updated to version 1.0
 

--- a/test/SFTPClient.qtest
+++ b/test/SFTPClient.qtest
@@ -6,7 +6,7 @@
 %strict-args
 %enable-all-warnings
 
-%requires ssh2 >= 1.0
+%requires ssh2 >= 1.1
 
 %requires Util
 %requires QUnit
@@ -35,7 +35,7 @@ class SFTPClientTest inherits QUnit::Test {
         const ColumnOffset = 25;
     }
 
-    constructor() : Test("SFTPClientTest", "1.0", \ARGV, MyOpts) {
+    constructor() : Test("SFTPClientTest", "1.1", \ARGV, MyOpts) {
         string uri = shift ARGV ?? sprintf("%s@localhost", getusername());
 
         sc = new SFTPClient(uri);

--- a/test/SftpPoller.qtest
+++ b/test/SftpPoller.qtest
@@ -6,7 +6,7 @@
 %strict-args
 %enable-all-warnings
 
-%requires ssh2 >= 1.0
+%requires ssh2 >= 1.1
 %requires ../qlib/SftpPoller.qm
 %requires QUnit
 %requires Util
@@ -93,7 +93,7 @@ class SftpPollerTest inherits QUnit::Test {
             );
     }
 
-    constructor() : Test("SftpPollerTest", "1.0", \ARGV, MyOpts) {
+    constructor() : Test("SftpPollerTest", "1.1", \ARGV, MyOpts) {
         addTestCase("SftpPollerTests", \sftpPollerTests());
         addTestCase("SftpPolerRemotePathNegTest", \sftpPollerRemotePathNegTest());
 

--- a/test/SftpPoller.qtest
+++ b/test/SftpPoller.qtest
@@ -33,7 +33,7 @@ class MySftpPoller inherits SftpPoller {
     }
 
     nothing postSingleFileEvent(hash fh) {
-        l += fh + ("data": sftp.getTextFile(fh.name));
+        l += fh;
     }
 
     list getFileList() {
@@ -78,6 +78,17 @@ class SftpPollerTest inherits QUnit::Test {
              "size": 3,
              "type": "REGULAR",
              "data": "cde",
+            ),
+            );
+
+        const NoRetrievalFiles = (
+            "x.txt": "abc",
+            );
+
+        const NoRetrievalResult = (
+            ("name": "x.txt",
+             "size": 3,
+             "type": "REGULAR",
             ),
             );
     }
@@ -152,6 +163,28 @@ class SftpPollerTest inherits QUnit::Test {
         # sort by file name
         fl = map $1.(Result[0].keys()), sort(fl, int sub (hash l, hash r) { return l.name <=> r.name; });
         assertEq(fl, Result);
+
+        # testing the data retrieval skipping (one file is enough)
+        string nd2 = sprintf("%s/", get_random_string());
+        sc.mkdir(nd2);
+        map sc.putFile($1.value, nd2 + $1.key), NoRetrievalFiles.pairIterator();
+        on_exit {
+            map sc.removeFile($1), NoRetrievalFiles.keyIterator();
+            sc.chdir("..");
+            sc.rmdir(nd2);
+        }
+
+        opts.path = nd2;
+        opts.skip_file_content_retrieval = True;
+
+        MySftpPoller poller2(sc, opts, m_options.verbose > 2);
+        poller2.start();
+        poller2.waitStop();
+        fl = poller2.getFileList();
+        map assertEq(False, exists $1.data), fl;
+        # sort by file name
+        fl = map $1.(NoRetrievalResult[0].keys()), sort(fl, int sub (hash l, hash r) { return l.name <=> r.name; });
+        assertEq(fl, NoRetrievalResult);
     }
 
     sftpPollerRemotePathNegTest() {

--- a/test/SftpPollerMultiDirs.qtest
+++ b/test/SftpPollerMultiDirs.qtest
@@ -6,7 +6,7 @@
 %strict-args
 %enable-all-warnings
 
-%requires ssh2 >= 1.0
+%requires ssh2 >= 1.1
 %requires ../qlib/SftpPoller.qm
 %requires QUnit
 %requires Util

--- a/test/ssh2-test.q
+++ b/test/ssh2-test.q
@@ -3,7 +3,7 @@
 
 %require-our
 %requires qore >= 0.8.12
-%requires ssh2 >= 1.0
+%requires ssh2 >= 1.1
 
 %requires Util
 


### PR DESCRIPTION
…eval' to SftpPoller that causes the SftpPoller to skip retrieving the content of the files being polled. As a consequence, the 'data' member is not available in singleFileEvent() and postSingleFileEvent() functions whenever this switch is True