### PR TITLE
Fix undefined reference to pthread issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(QORE_DOX_TMPL_SRC
 )
 
 add_library(${module_name} MODULE ${CPP_SRC} ${QPP_SOURCES})
+target_link_libraries(${module_name} ${CMAKE_THREAD_LIBS_INIT})
 set(MODULE_DOX_INPUT ${CMAKE_BINARY_DIR}/mainpage.dox ${_dox_src})
 qore_external_binary_module(${module_name} ${PROJECT_VERSION} ${LIBSSH2_LDFLAGS})
 

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ INTRODUCTION
 This module provides access to ssh2 sessions and the sftp protocol via libssh2
 (http://www.libssh2.org) in the Qore programming language.
 
-This version requires qore 0.8.13+ as it requires qpp to build (qpp is the Qore
+This version requires qore 0.9.0+ as it requires qpp to build (qpp is the Qore
 Pre-Processor) and the stream API
 
 LICENSE


### PR DESCRIPTION
The pthreads library was not linked to compiling failed on some
systems with an
> QoreThreadLocalStorage.h:73: undefined reference to `pthread_key_delete'

error

Align minimum qore version inside README with the one required in the CMakeLists.txt