### PR TITLE
fix(security): secure host-key verification by default + embedder controls

### DIFF
--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -68,6 +68,47 @@
     - Common exceptions: \c SSH2-ERROR, \c SSH2CLIENT-TIMEOUT, \c SFTPCLIENT-TIMEOUT
     - Check the \c authenticated key in @ref Qore::SSH2::SSH2Client::info() "info()" to verify successful authentication
 
+    @subsection host_key_verification_bp Host Key Verification
+    - Host key verification is <b>enabled by default</b> with the @ref SSH2_HOSTKEY_TOFU
+      (Trust On First Use) policy and the local user's <tt>~/.ssh/known_hosts</tt> file; this
+      protects against man-in-the-middle attacks on all but the first connection to a given host
+    - For strict checking, pre-populate the known_hosts file and set
+      @ref Qore::SSH2::SSH2Base::setHostKeyPolicy() "setHostKeyPolicy(SSH2_HOSTKEY_REJECT)" so
+      that any unknown host key is rejected
+    - Disabling verification with
+      @ref Qore::SSH2::SSH2Base::setVerifyHostKey() "setVerifyHostKey(False)" removes
+      man-in-the-middle protection entirely and should only be done if the risk is fully
+      understood and accepted
+    - A connection will fail with an \c SSH2-HOSTKEY-ERROR exception if the configured
+      known_hosts file exists but cannot be read or parsed, rather than silently connecting
+      without verification
+
+    @subsection embedding_multitenant Embedding in Multi-Tenant Applications
+    In an embedding application where the OS/UNIX user running the process is unrelated to the
+    logical user making SSH/SFTP connections (for example, an integration server such as Qorus),
+    the OS user's <tt>~/.ssh/known_hosts</tt> file must not be used: it is shared across all
+    logical users and host keys accepted (and persisted via @ref SSH2_HOSTKEY_TOFU "TOFU") for one
+    logical user would be trusted for all of them.
+
+    Such applications should change the <b>process-global</b> defaults once at startup instead of
+    relying on every call site:
+    - @ref Qore::SSH2::SSH2Base::setDefaultKnownHostsFile() "SSH2Base::setDefaultKnownHostsFile(\"\")"
+      disables use of any implicit known_hosts file (host key trust should then be managed per
+      connection, e.g. via the \c known_hosts connection option); passing a path makes that path
+      the default instead
+    - @ref Qore::SSH2::SSH2Base::setDefaultVerifyHostKey() "SSH2Base::setDefaultVerifyHostKey()"
+      and @ref Qore::SSH2::SSH2Base::setDefaultHostKeyPolicy() "SSH2Base::setDefaultHostKeyPolicy()"
+      change the global verification and policy defaults
+    - the same defaults can be set at deployment time with the \c QORE_SSH2_DEFAULT_KNOWN_HOSTS
+      (unset = built-in per-user default; empty = disabled; a path = that path),
+      \c QORE_SSH2_DEFAULT_VERIFY_HOST_KEY, and \c QORE_SSH2_DEFAULT_HOST_KEY_POLICY environment
+      variables
+
+    Precedence (highest to lowest): a per-object setter (e.g. @ref Qore::SSH2::SSH2Base::setKnownHostsFile()
+    "setKnownHostsFile()") > a process-global \c setDefault*() call > the \c QORE_SSH2_DEFAULT_*
+    environment variable > the built-in secure default. Process-global defaults affect only
+    objects created after they are set.
+
     @section examples Examples
 
     Example of a basic sftp connection:
@@ -145,11 +186,29 @@ stdout.printf("exit status: %d\n", chan.getExitStatus());@endcode
       (@ref Qore::SSH2::SSH2Base::setKeysFromData() "SSH2Base::setKeysFromData()")
 
     <b>Security - Known Hosts Verification:</b>
+    - <b>host key verification is now enabled by default</b> (secure by default) using the
+      @ref SSH2_HOSTKEY_TOFU policy and the local user's <tt>~/.ssh/known_hosts</tt> file
+      (resolved automatically when filesystem access is permitted); this closes a
+      man-in-the-middle vulnerability where the previous default silently connected to any server
+      and could disclose credentials to an attacker
     - added known hosts file support for host key verification
       (@ref Qore::SSH2::SSH2Base::setKnownHostsFile() "SSH2Base::setKnownHostsFile()",
       @ref Qore::SSH2::SSH2Base::setVerifyHostKey() "SSH2Base::setVerifyHostKey()")
-    - configurable host key policy: REJECT (default) or TOFU (Trust On First Use)
+    - configurable host key policy: TOFU (default, Trust On First Use) or REJECT
       (@ref Qore::SSH2::SSH2Base::setHostKeyPolicy() "SSH2Base::setHostKeyPolicy()")
+    - a configured known_hosts file that exists but cannot be read or parsed now causes the
+      connection to fail with \c SSH2-HOSTKEY-ERROR instead of silently connecting without
+      verification (fail closed)
+    - the plaintext authentication password is no longer written to debug output
+    - added process-global default controls for embedding applications (e.g. multi-tenant hosts
+      where the OS user differs from the logical user, where the OS user's
+      <tt>~/.ssh/known_hosts</tt> must not be used):
+      @ref Qore::SSH2::SSH2Base::setDefaultVerifyHostKey() "SSH2Base::setDefaultVerifyHostKey()",
+      @ref Qore::SSH2::SSH2Base::setDefaultHostKeyPolicy() "SSH2Base::setDefaultHostKeyPolicy()",
+      @ref Qore::SSH2::SSH2Base::setDefaultKnownHostsFile() "SSH2Base::setDefaultKnownHostsFile()"
+      (and corresponding \c getDefault*() methods), plus the \c QORE_SSH2_DEFAULT_VERIFY_HOST_KEY,
+      \c QORE_SSH2_DEFAULT_HOST_KEY_POLICY, and \c QORE_SSH2_DEFAULT_KNOWN_HOSTS environment
+      variables; see @ref embedding_multitenant
     - added @ref Qore::SSH2::SSH2Base::getHostKey() "SSH2Base::getHostKey()" returning MD5/SHA1/SHA256 fingerprints
     - added @ref Qore::SSH2::SSH2Base::addKnownHost() "SSH2Base::addKnownHost()" for manual host key management
     - added \c SSH2_HOSTKEY_REJECT and \c SSH2_HOSTKEY_TOFU constants
@@ -199,6 +258,8 @@ stdout.printf("exit status: %d\n", chan.getExitStatus());@endcode
 
     <b>Connection Module Updates:</b>
     - added \c known_hosts, \c verify_host_key, \c use_agent, and \c keepalive_interval connection options
+    - the \c verify_host_key connection option now defaults to @ref Qore::True "True" (secure by
+      default), consistent with the underlying client classes
 
     <b>Bug Fixes:</b>
     - removed stale TODO in mkdir implementation

--- a/qlib/Ssh2Connections.qm
+++ b/qlib/Ssh2Connections.qm
@@ -65,6 +65,18 @@ module Ssh2Connections {
 
     @section ssh2connections_relnotes Ssh2Connections Module Release History
 
+    @subsection ssh2connections_v2_0 Ssh2Connections v2.0
+    - the \c verify_host_key connection option now defaults to @ref Qore::True "True" (secure by
+      default) and an explicit @ref Qore::False "False" is honored, consistent with the ssh2
+      client classes
+    - the \c verify_host_key option's reported default in connection introspection now reflects
+      the ssh2 module's effective process-global host key verification default (which an embedding
+      application may change via \c SSH2Base::setDefaultVerifyHostKey() or the
+      \c QORE_SSH2_DEFAULT_VERIFY_HOST_KEY environment variable)
+    - if the \c known_hosts option is not set, the ssh2 module default applies (normally the local
+      user's <tt>~/.ssh/known_hosts</tt> file, unless the embedding application has changed or
+      disabled the module default)
+
     @subsection ssh2connections_v1_4 Ssh2Connections v1.4
     - implemented support for a data provider scheme cache and rich option information for connections
       (<a href="https://github.com/qorelanguage/qore/issues/4025">issue 4025</a>)
@@ -153,15 +165,21 @@ public class Ssh2ClientConnection inherits AbstractSsh2Connection {
                     "short_desc": "A path to an OpenSSH known_hosts file for host key verification",
                     "type": "string",
                     "desc": "A path to an OpenSSH known_hosts file for host key verification; "
-                        "environment variables can be prefixed with '$' in the path",
+                        "environment variables can be prefixed with '$' in the path; if not set, "
+                        "the ssh2 module default applies (normally the local user's "
+                        "~/.ssh/known_hosts file, unless the embedding application has changed or "
+                        "disabled the module default)",
                 },
                 "verify_host_key": <ConnectionOptionInfo>{
                     "display_name": "Verify Host Key",
                     "short_desc": "Enable host key verification against the known_hosts file",
                     "type": "bool",
-                    "desc": "Enable host key verification against the known_hosts file; "
-                        "requires the 'known_hosts' option to be set",
-                    "default_value": False,
+                    "desc": "Enable host key verification against the known_hosts file; enabled by "
+                        "default; the effective default follows the ssh2 module's process-global "
+                        "default, which an embedding application may change via "
+                        "SSH2Base::setDefaultVerifyHostKey() or the "
+                        "QORE_SSH2_DEFAULT_VERIFY_HOST_KEY environment variable",
+                    "default_value": True,
                 },
                 "use_agent": <ConnectionOptionInfo>{
                     "display_name": "Use SSH Agent",
@@ -238,7 +256,7 @@ public class Ssh2ClientConnection inherits AbstractSsh2Connection {
         if (opts.known_hosts) {
             sc.setKnownHostsFile(substitute_env_vars(opts.known_hosts));
         }
-        if (opts.verify_host_key) {
+        if (exists opts.verify_host_key) {
             sc.setVerifyHostKey(opts.verify_host_key);
         }
         if (exists opts.use_agent) {
@@ -255,7 +273,13 @@ public class Ssh2ClientConnection inherits AbstractSsh2Connection {
 
     #! Returns the ConnectionSchemeInfo hash for this object
     private hash<ConnectionSchemeInfo> getConnectionSchemeInfoImpl() {
-        return ConnectionScheme;
+        # reflect the ssh2 module's process-global host key verification default so that
+        # connection introspection is consistent with the effective runtime default (which an
+        # embedding application may have changed via SSH2Base::setDefaultVerifyHostKey() or the
+        # QORE_SSH2_DEFAULT_VERIFY_HOST_KEY environment variable)
+        hash<ConnectionSchemeInfo> scheme = ConnectionScheme;
+        scheme.options.verify_host_key.default_value = SSH2Base::getDefaultVerifyHostKey();
+        return scheme;
     }
 }
 
@@ -287,15 +311,21 @@ public class SftpConnection inherits AbstractSsh2Connection {
                     "short_desc": "A path to an OpenSSH known_hosts file for host key verification",
                     "type": "string",
                     "desc": "A path to an OpenSSH known_hosts file for host key verification; "
-                        "environment variables can be prefixed with '$' in the path",
+                        "environment variables can be prefixed with '$' in the path; if not set, "
+                        "the ssh2 module default applies (normally the local user's "
+                        "~/.ssh/known_hosts file, unless the embedding application has changed or "
+                        "disabled the module default)",
                 },
                 "verify_host_key": <ConnectionOptionInfo>{
                     "display_name": "Verify Host Key",
                     "short_desc": "Enable host key verification against the known_hosts file",
                     "type": "bool",
-                    "desc": "Enable host key verification against the known_hosts file; "
-                        "requires the 'known_hosts' option to be set",
-                    "default_value": False,
+                    "desc": "Enable host key verification against the known_hosts file; enabled by "
+                        "default; the effective default follows the ssh2 module's process-global "
+                        "default, which an embedding application may change via "
+                        "SSH2Base::setDefaultVerifyHostKey() or the "
+                        "QORE_SSH2_DEFAULT_VERIFY_HOST_KEY environment variable",
+                    "default_value": True,
                 },
                 "use_agent": <ConnectionOptionInfo>{
                     "display_name": "Use SSH Agent",
@@ -500,7 +530,7 @@ public class SftpConnection inherits AbstractSsh2Connection {
         if (opts.known_hosts) {
             sc.setKnownHostsFile(substitute_env_vars(opts.known_hosts));
         }
-        if (opts.verify_host_key) {
+        if (exists opts.verify_host_key) {
             sc.setVerifyHostKey(opts.verify_host_key);
         }
         if (exists opts.use_agent) {
@@ -530,7 +560,13 @@ public class SftpConnection inherits AbstractSsh2Connection {
 
     #! Returns the ConnectionSchemeInfo hash for this object
     private hash<ConnectionSchemeInfo> getConnectionSchemeInfoImpl() {
-        return ConnectionScheme;
+        # reflect the ssh2 module's process-global host key verification default so that
+        # connection introspection is consistent with the effective runtime default (which an
+        # embedding application may have changed via SSH2Base::setDefaultVerifyHostKey() or the
+        # QORE_SSH2_DEFAULT_VERIFY_HOST_KEY environment variable)
+        hash<ConnectionSchemeInfo> scheme = ConnectionScheme;
+        scheme.options.verify_host_key.default_value = SSH2Base::getDefaultVerifyHostKey();
+        return scheme;
     }
 }
 }

--- a/src/QC_SSH2Base.qpp
+++ b/src/QC_SSH2Base.qpp
@@ -329,6 +329,10 @@ int SSH2Base::getPort() {
 /** @par Example:
     @code{.py} ssh2client.setKnownHostsFile(ENV.HOME + "/.ssh/known_hosts"); @endcode
 
+    By default (i.e. if this method is not called), the local user's <tt>~/.ssh/known_hosts</tt>
+    file is used automatically when filesystem access is permitted; call this method only to
+    override that default with a different path.
+
     @param path the path to the known_hosts file (OpenSSH format)
 
     @throw SSH2-CONNECTED this method cannot be called when a connection is established
@@ -343,7 +347,10 @@ nothing SSH2Base::setKnownHostsFile(string path) [dom=FILESYSTEM] {
 /** @par Example:
     @code{.py} *string path = ssh2client.getKnownHostsFile(); @endcode
 
-    @return the known hosts file path or \c NOTHING if not set
+    @return the known hosts file path or \c NOTHING if not set; note that by default this is the
+    local user's <tt>~/.ssh/known_hosts</tt> file (resolved at object creation when filesystem
+    access is permitted), so this normally returns that path even if @ref setKnownHostsFile() was
+    never called
 
     @since ssh2 2.0
 */
@@ -361,10 +368,17 @@ ssh2client.setVerifyHostKey(True);
     @endcode
 
     When enabled, the server's host key is checked against the known_hosts file during
-    connection. A known_hosts file must be configured with @ref setKnownHostsFile() before
-    enabling verification.
+    connection. Host key verification is <b>enabled by default</b> with the
+    @ref SSH2_HOSTKEY_TOFU policy and the local user's <tt>~/.ssh/known_hosts</tt> file (see
+    @ref setKnownHostsFile() and @ref setHostKeyPolicy()).
 
-    @param verify set to @ref Qore::True "True" to enable host key verification
+    @warning Disabling host key verification (passing @ref Qore::False "False") makes the
+    connection vulnerable to man-in-the-middle attacks, as the identity of the server is no longer
+    verified and credentials may be sent to an attacker; only disable verification if you fully
+    understand and accept this risk.
+
+    @param verify set to @ref Qore::True "True" to enable host key verification (the default) or
+    @ref Qore::False "False" to disable it
 
     @throw SSH2-CONNECTED this method cannot be called when a connection is established
 
@@ -382,7 +396,8 @@ nothing SSH2Base::setVerifyHostKey(bool verify) {
 /** @par Example:
     @code{.py} bool verify = ssh2client.getVerifyHostKey(); @endcode
 
-    @return @ref Qore::True "True" if host key verification is enabled
+    @return @ref Qore::True "True" if host key verification is enabled; note that host key
+    verification is enabled by default
 
     @since ssh2 2.0
 */
@@ -396,8 +411,8 @@ bool SSH2Base::getVerifyHostKey() [flags=CONSTANT] {
 
     Controls what happens when host key verification is enabled and the server's key is not
     found in the known_hosts file:
-    - \c SSH2_HOSTKEY_REJECT (default): raise an \c SSH2-HOSTKEY-UNKNOWN exception
-    - \c SSH2_HOSTKEY_TOFU (Trust On First Use): accept the key and add it to the known_hosts file
+    - \c SSH2_HOSTKEY_REJECT: raise an \c SSH2-HOSTKEY-UNKNOWN exception
+    - \c SSH2_HOSTKEY_TOFU (default, Trust On First Use): accept the key and add it to the known_hosts file
 
     @param policy the policy constant: \c SSH2_HOSTKEY_REJECT or \c SSH2_HOSTKEY_TOFU
 
@@ -413,12 +428,169 @@ nothing SSH2Base::setHostKeyPolicy(int policy) {
 /** @par Example:
     @code{.py} int policy = ssh2client.getHostKeyPolicy(); @endcode
 
-    @return the current host key policy: \c SSH2_HOSTKEY_REJECT or \c SSH2_HOSTKEY_TOFU
+    @return the current host key policy: \c SSH2_HOSTKEY_REJECT or \c SSH2_HOSTKEY_TOFU; the
+    default is \c SSH2_HOSTKEY_TOFU
 
     @since ssh2 2.0
 */
 int SSH2Base::getHostKeyPolicy() [flags=CONSTANT] {
     return myself->getHostKeyPolicy();
+}
+
+//! Sets the process-global default for host key verification for subsequently-created objects
+/** @par Example:
+    @code{.py} SSH2Base::setDefaultVerifyHostKey(False); @endcode
+
+    This sets a process-global default that is applied to every @ref SSH2Client and @ref SFTPClient
+    object constructed afterwards (anywhere in the process), unless overridden on the object itself
+    with @ref setVerifyHostKey(). It is intended for embedding applications (for example, where the
+    OS user running the process differs from the logical user making connections) that need to
+    change the secure-by-default behavior globally rather than at every call site.
+
+    The process-global default can also be set with the \c QORE_SSH2_DEFAULT_VERIFY_HOST_KEY
+    environment variable; an explicit call to this method overrides the environment variable, and
+    a per-object call to @ref setVerifyHostKey() overrides this default.
+
+    @param verify @ref Qore::True "True" to verify host keys by default, @ref Qore::False "False" to disable
+
+    @note this affects only objects created after this call; existing objects are unaffected
+
+    @see
+    - @ref setVerifyHostKey()
+    - @ref getDefaultVerifyHostKey()
+
+    @since ssh2 2.0
+*/
+static nothing SSH2Base::setDefaultVerifyHostKey(bool verify) {
+    ssh2_set_default_verify_host_key(verify);
+}
+
+//! Returns the process-global default for host key verification
+/** @par Example:
+    @code{.py} bool verify = SSH2Base::getDefaultVerifyHostKey(); @endcode
+
+    @return @ref Qore::True "True" if host key verification is enabled by default (the built-in
+    default); @ref Qore::False "False" if it has been disabled globally
+
+    @see @ref setDefaultVerifyHostKey()
+
+    @since ssh2 2.0
+*/
+static bool SSH2Base::getDefaultVerifyHostKey() [flags=CONSTANT] {
+    return ssh2_get_default_verify_host_key();
+}
+
+//! Sets the process-global default host key policy for subsequently-created objects
+/** @par Example:
+    @code{.py} SSH2Base::setDefaultHostKeyPolicy(SSH2_HOSTKEY_REJECT); @endcode
+
+    Sets the process-global default policy applied to every @ref SSH2Client and @ref SFTPClient
+    object constructed afterwards, unless overridden on the object with @ref setHostKeyPolicy().
+    Can also be set with the \c QORE_SSH2_DEFAULT_HOST_KEY_POLICY environment variable
+    (\c "reject" or \c "tofu"); an explicit call to this method overrides the environment variable.
+
+    @param policy the policy constant: \c SSH2_HOSTKEY_REJECT or \c SSH2_HOSTKEY_TOFU
+
+    @throw SSH2-HOSTKEY-POLICY-ERROR invalid policy value
+
+    @note this affects only objects created after this call; existing objects are unaffected
+
+    @see
+    - @ref setHostKeyPolicy()
+    - @ref getDefaultHostKeyPolicy()
+
+    @since ssh2 2.0
+*/
+static nothing SSH2Base::setDefaultHostKeyPolicy(int policy) {
+    if (ssh2_set_default_host_key_policy((int)policy)) {
+        xsink->raiseException("SSH2-HOSTKEY-POLICY-ERROR", "invalid host key policy %d; expected SSH2_HOSTKEY_REJECT (%d) or SSH2_HOSTKEY_TOFU (%d)", (int)policy, SSH2_HOSTKEY_REJECT, SSH2_HOSTKEY_TOFU);
+    }
+}
+
+//! Returns the process-global default host key policy
+/** @par Example:
+    @code{.py} int policy = SSH2Base::getDefaultHostKeyPolicy(); @endcode
+
+    @return the process-global default host key policy: \c SSH2_HOSTKEY_REJECT or
+    \c SSH2_HOSTKEY_TOFU (the built-in default is \c SSH2_HOSTKEY_TOFU)
+
+    @see @ref setDefaultHostKeyPolicy()
+
+    @since ssh2 2.0
+*/
+static int SSH2Base::getDefaultHostKeyPolicy() [flags=CONSTANT] {
+    return ssh2_get_default_host_key_policy();
+}
+
+//! Sets the process-global default known_hosts file behavior for subsequently-created objects
+/** @par Example:
+    @code{.py}
+# disable use of any implicit known_hosts file (e.g. in a multi-tenant host where the OS user
+# differs from the logical user making connections)
+SSH2Base::setDefaultKnownHostsFile("");
+    @endcode
+
+    Controls which known_hosts file newly-constructed @ref SSH2Client and @ref SFTPClient objects
+    use by default (unless overridden on the object with @ref setKnownHostsFile()):
+    - \a path = @ref nothing "NOTHING": use the built-in default (the local OS user's
+      <tt>~/.ssh/known_hosts</tt>, when filesystem access is permitted)
+    - \a path = an empty string (\c ""): do not use any implicit known_hosts file; intended for
+      embedding applications (e.g. Qorus) where the OS user running the process is unrelated to
+      the logical user making the connection, so the OS user's <tt>~/.ssh/known_hosts</tt> must
+      not be used (host key trust should then be managed per connection)
+    - \a path = a non-empty string: use this path as the default known_hosts file for all
+      subsequently-created objects
+
+    Can also be set with the \c QORE_SSH2_DEFAULT_KNOWN_HOSTS environment variable (unset = built-in
+    default; set but empty = disabled; set to a path = that path); an explicit call to this method
+    overrides the environment variable, and a per-object call to @ref setKnownHostsFile() overrides
+    this default.
+
+    @param path @ref nothing "NOTHING" for the built-in default, an empty string to disable any
+    implicit known_hosts file, or a path to use as the default
+
+    @note this affects only objects created after this call; existing objects are unaffected
+
+    @see
+    - @ref setKnownHostsFile()
+    - @ref getDefaultKnownHostsFile()
+
+    @since ssh2 2.0
+*/
+static nothing SSH2Base::setDefaultKnownHostsFile(*string path) [dom=FILESYSTEM] {
+    if (!path) {
+        ssh2_set_default_known_hosts(SSH2_KH_DEFAULT_AUTO, nullptr);
+    } else if (path->empty()) {
+        ssh2_set_default_known_hosts(SSH2_KH_DEFAULT_DISABLED, nullptr);
+    } else {
+        ssh2_set_default_known_hosts(SSH2_KH_DEFAULT_EXPLICIT, path->c_str());
+    }
+}
+
+//! Returns the process-global default known_hosts file configuration
+/** @par Example:
+    @code{.py} *string def = SSH2Base::getDefaultKnownHostsFile(); @endcode
+
+    @return one of:
+    - @ref nothing "NOTHING": the built-in default is in effect (the local OS user's
+      <tt>~/.ssh/known_hosts</tt>, resolved per object when filesystem access is permitted)
+    - an empty string (\c ""): use of any implicit known_hosts file has been disabled globally
+    - a non-empty string: the configured default known_hosts file path
+
+    @see @ref setDefaultKnownHostsFile()
+
+    @since ssh2 2.0
+*/
+static *string SSH2Base::getDefaultKnownHostsFile() [flags=CONSTANT] {
+    std::string path;
+    int mode = ssh2_get_default_known_hosts(path);
+    if (mode == SSH2_KH_DEFAULT_DISABLED) {
+        return new QoreStringNode;
+    }
+    if (mode == SSH2_KH_DEFAULT_EXPLICIT) {
+        return new QoreStringNode(path.c_str());
+    }
+    return (QoreStringNode*)nullptr;
 }
 
 //! Returns information about the connected server's host key

--- a/src/SSH2Client.cpp
+++ b/src/SSH2Client.cpp
@@ -99,10 +99,10 @@ static void map_ssh2_sbuf_to_hash(QoreHashNode *h, struct stat *sbuf, ExceptionS
     // note that dev_t on Linux is an unsigned 64-bit integer, so we could lose precision here
     h->setKeyValue("mode",        sbuf->st_mode, xsink);
     h->setKeyValue("permissions", new QoreStringNode(mode2str(sbuf->st_mode)), xsink);
-    h->setKeyValue("size",        sbuf->st_size, xsink);
+    h->setKeyValue("size",        (int64)sbuf->st_size, xsink);
 
-    h->setKeyValue("uid",         sbuf->st_uid, xsink);
-    h->setKeyValue("gid",         sbuf->st_gid, xsink);
+    h->setKeyValue("uid",         (int64)sbuf->st_uid, xsink);
+    h->setKeyValue("gid",         (int64)sbuf->st_gid, xsink);
 
     h->setKeyValue("atime",       DateTimeNode::makeAbsolute(currentTZ(), (int64)sbuf->st_atime), xsink);
     h->setKeyValue("mtime",       DateTimeNode::makeAbsolute(currentTZ(), (int64)sbuf->st_mtime), xsink);
@@ -113,25 +113,27 @@ static void map_ssh2_sbuf_to_hash(QoreHashNode *h, struct stat *sbuf, ExceptionS
  *
  * this just prefills the values for connection with hostname and port
  */
-SSH2Client::SSH2Client(const char *hostname, const uint32_t port) : sshhost(hostname), sshport(port), keepalive_interval(QKEEPALIVE_DEFAULT), use_agent(true), verify_host_key(false), host_key_policy(SSH2_HOSTKEY_REJECT), sshauthenticatedwith(0), ssh_session(0) {
+SSH2Client::SSH2Client(const char *hostname, const uint32_t port) : sshhost(hostname), verify_host_key(ssh2_get_default_verify_host_key()), host_key_policy(ssh2_get_default_host_key_policy()), sshport(port), keepalive_interval(QKEEPALIVE_DEFAULT), use_agent(true), sshauthenticatedwith(0), ssh_session(0) {
     setKeysIntern();
+    setKnownHostsIntern();
 }
 
 SSH2Client::SSH2Client(QoreURL &url, const uint32_t port) :
     sshhost(url.getHost() ? url.getHost()->getBuffer() : ""),
     sshuser(url.getUserName() ? url.getUserName()->getBuffer() : ""),
     sshpass(url.getPassword() ? url.getPassword()->getBuffer() : ""),
+    verify_host_key(ssh2_get_default_verify_host_key()),
+    host_key_policy(ssh2_get_default_host_key_policy()),
     sshport(port ? port : (uint32_t)url.getPort()),
     keepalive_interval(QKEEPALIVE_DEFAULT),
     use_agent(true),
-    verify_host_key(false),
-    host_key_policy(SSH2_HOSTKEY_REJECT),
     sshauthenticatedwith(0),
     ssh_session(0) {
     if (!sshport)
         sshport = DEFAULT_SSH_PORT;
 
     setKeysIntern();
+    setKnownHostsIntern();
 }
 
 /*
@@ -178,6 +180,44 @@ void SSH2Client::setKeysIntern() {
         if (sshuser.empty()) {
             sshuser = usrpwd->pw_name;
         }
+    }
+#endif
+}
+
+void SSH2Client::setKnownHostsIntern() {
+    std::string explicit_path;
+    int mode = ssh2_get_default_known_hosts(explicit_path);
+
+    if (mode == SSH2_KH_DEFAULT_DISABLED) {
+        // no implicit known_hosts file; used by embedding applications (e.g. Qorus) where the OS
+        // user running the process differs from the logical user making the connection, so the
+        // OS user's ~/.ssh/known_hosts must not be used
+        return;
+    }
+
+    if (mode == SSH2_KH_DEFAULT_EXPLICIT) {
+        // an explicitly-configured default path is a deliberate choice and is honored regardless
+        // of PO_NO_FILESYSTEM (sandboxing is still enforced at actual file-access time)
+        known_hosts_file = explicit_path;
+        printd(5, "SSH2Client::setKnownHostsIntern() set configured default known_hosts file: '%s'\n", known_hosts_file.c_str());
+        return;
+    }
+
+    // SSH2_KH_DEFAULT_AUTO: the local OS user's ~/.ssh/known_hosts
+#ifdef HAVE_PWD_H
+    // do not access the filesystem to find the known_hosts file if filesystem access is not allowed
+    if (getProgram()->getParseOptions() & PO_NO_FILESYSTEM) {
+        return;
+    }
+
+    // the known_hosts file belongs to the local OS user running the program, not the remote SSH
+    // user, so it is resolved independently of sshuser; the file does not need to exist (it will be
+    // created on first use with the default SSH2_HOSTKEY_TOFU policy)
+    struct passwd* usrpwd = getpwuid(getuid());
+    if (usrpwd && usrpwd->pw_dir && usrpwd->pw_dir[0]) {
+        known_hosts_file = usrpwd->pw_dir;
+        known_hosts_file += "/.ssh/known_hosts";
+        printd(5, "SSH2Client::setKnownHostsIntern() set default known_hosts file: '%s'\n", known_hosts_file.c_str());
     }
 #endif
 }
@@ -530,9 +570,25 @@ int SSH2Client::sshConnectUnlocked(int timeout_ms, ExceptionSink *xsink = 0) {
             return -1;
         }
 
-        // load known hosts file if specified
+        // load the known hosts file if specified; a non-existent file is normal for the first
+        // connection under the SSH2_HOSTKEY_TOFU policy (the file is created on first use), but a
+        // file that exists and cannot be read or parsed must NOT be silently ignored, as that
+        // would bypass host key verification entirely (degrading to "trust anything")
         if (!known_hosts_file.empty()) {
-            libssh2_knownhost_readfile(nh, known_hosts_file.c_str(), LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+            struct stat sb;
+            if (!stat(known_hosts_file.c_str(), &sb)) {
+                int read_rc = libssh2_knownhost_readfile(nh, known_hosts_file.c_str(),
+                    LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+                if (read_rc < 0) {
+                    libssh2_knownhost_free(nh);
+                    disconnectUnlocked(true);
+                    xsink && xsink->raiseException("SSH2-HOSTKEY-ERROR",
+                        "the configured known_hosts file '%s' exists but could not be read or "
+                        "parsed (libssh2 error code %d); refusing to connect to avoid bypassing "
+                        "host key verification", known_hosts_file.c_str(), read_rc);
+                    return -1;
+                }
+            }
         }
 
         // determine key type for check
@@ -745,7 +801,7 @@ int SSH2Client::sshConnectUnlocked(int timeout_ms, ExceptionSink *xsink = 0) {
 
     // try password and keyboard-interactive first if a password was given
     if (!loggedin && (auth_pw & QAUTH_PASSWORD)) {
-        printd(5, "SSH2Client::connect(): try user/pass auth: %s/%s\n", sshuser.c_str(), sshpass.c_str());
+        printd(5, "SSH2Client::connect(): try user/pass auth: %s/<redacted>\n", sshuser.c_str());
         while ((rc = libssh2_userauth_password(ssh_session, sshuser.c_str(), sshpass.c_str())) == LIBSSH2_ERROR_EAGAIN) {
             if (waitSocketUnlocked(xsink, SSH2CLIENT_TIMEOUT, SSH2_ERROR, "SSH2Client::connect", timeout_ms)) {
                 disconnectUnlocked(true); // clean up connection
@@ -764,7 +820,7 @@ int SSH2Client::sshConnectUnlocked(int timeout_ms, ExceptionSink *xsink = 0) {
     }
 
     if (!loggedin && (auth_pw & QAUTH_KEYBOARD_INTERACTIVE)) {
-        printd(5, "SSH2Client::connect(): try user/pass with keyboard-interactive auth: %s/%s\n", sshuser.c_str(), sshpass.c_str());
+        printd(5, "SSH2Client::connect(): try user/pass with keyboard-interactive auth: %s/<redacted>\n", sshuser.c_str());
         // thread thread-local storage for password for fake keyboard-interactive authentication
         keyboardPassword.set(sshpass.c_str());
         while ((rc = libssh2_userauth_keyboard_interactive(ssh_session, sshuser.c_str(), &kbd_callback)) == LIBSSH2_ERROR_EAGAIN) {
@@ -1024,8 +1080,22 @@ int SSH2Client::addKnownHostLocked(const char* host, int port, ExceptionSink* xs
         return -1;
     }
 
-    // load existing file
-    libssh2_knownhost_readfile(nh, known_hosts_file.c_str(), LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+    // load the existing known hosts file if present; if it exists but cannot be read or parsed,
+    // fail rather than silently overwriting it (which would discard or mask existing entries)
+    {
+        struct stat sb;
+        if (!stat(known_hosts_file.c_str(), &sb)) {
+            int read_rc = libssh2_knownhost_readfile(nh, known_hosts_file.c_str(),
+                LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+            if (read_rc < 0) {
+                libssh2_knownhost_free(nh);
+                xsink->raiseException("SSH2-HOSTKEY-ERROR",
+                    "the known_hosts file '%s' exists but could not be read or parsed (libssh2 "
+                    "error code %d)", known_hosts_file.c_str(), read_rc);
+                return -1;
+            }
+        }
+    }
 
     // determine key type
     int kh_type = LIBSSH2_KNOWNHOST_TYPE_PLAIN | LIBSSH2_KNOWNHOST_KEYENC_RAW;
@@ -1324,13 +1394,7 @@ LIBSSH2_CHANNEL* SSH2Client::scpGetRaw(ExceptionSink *xsink, const char *path, i
 
     // write file status info to statinfo if available
     if (statinfo) {
-        statinfo->setKeyValue("mode", sb.st_mode, xsink);
-        statinfo->setKeyValue("permissions", new QoreStringNode(mode2str(sb.st_mode)), xsink);
-        statinfo->setKeyValue("size", (int64)sb.st_size, xsink);
-        statinfo->setKeyValue("uid", (int64)sb.st_uid, xsink);
-        statinfo->setKeyValue("gid", (int64)sb.st_gid, xsink);
-        statinfo->setKeyValue("atime", DateTimeNode::makeAbsolute(currentTZ(), (int64)sb.st_atime), xsink);
-        statinfo->setKeyValue("mtime", DateTimeNode::makeAbsolute(currentTZ(), (int64)sb.st_mtime), xsink);
+        map_ssh2_sbuf_to_hash(statinfo, &sb, xsink);
     }
 #else
     struct stat sb;

--- a/src/SSH2Client.cpp
+++ b/src/SSH2Client.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <map>
 #include <utility>
+#include <cstring>
 #include <sys/types.h>
 #ifdef HAVE_PWD_H
 #include <pwd.h>
@@ -106,6 +107,39 @@ static void map_ssh2_sbuf_to_hash(QoreHashNode *h, struct stat *sbuf, ExceptionS
 
     h->setKeyValue("atime",       DateTimeNode::makeAbsolute(currentTZ(), (int64)sbuf->st_atime), xsink);
     h->setKeyValue("mtime",       DateTimeNode::makeAbsolute(currentTZ(), (int64)sbuf->st_mtime), xsink);
+}
+
+// ensure the parent directory of the given file path exists, creating it with mode 0700 if it
+// does not. This is needed for the auto-resolved ~/.ssh/known_hosts file under the TOFU policy:
+// on a fresh account ~/.ssh may not exist yet, and without it libssh2_knownhost_writefile()
+// fails and the accepted host key is never persisted, leaving every subsequent connection a
+// first-use (and therefore man-in-the-middle) opportunity. Returns 0 if the parent directory
+// exists or was created, -1 with errno set otherwise.
+static int ensure_parent_dir(const char* path) {
+    const char* slash = strrchr(path, '/');
+    if (!slash || slash == path) {
+        // no parent component (a bare relative name, or the filesystem root itself): nothing to
+        // create - leave any failure to be reported by the subsequent write
+        return 0;
+    }
+    std::string dir(path, slash - path);
+    struct stat sb;
+    if (!stat(dir.c_str(), &sb)) {
+        if (S_ISDIR(sb.st_mode)) {
+            return 0;
+        }
+        errno = ENOTDIR;
+        return -1;
+    }
+    if (errno != ENOENT) {
+        // the parent itself is inaccessible (EACCES, ENOTDIR on a path component, ...)
+        return -1;
+    }
+    // 0700: the known_hosts directory (typically ~/.ssh) must not be group- or world-accessible
+    if (mkdir(dir.c_str(), 0700) && errno != EEXIST) {
+        return -1;
+    }
+    return 0;
 }
 
 /**
@@ -588,6 +622,20 @@ int SSH2Client::sshConnectUnlocked(int timeout_ms, ExceptionSink *xsink = 0) {
                         "host key verification", known_hosts_file.c_str(), read_rc);
                     return -1;
                 }
+            } else if (errno != ENOENT) {
+                // only a genuine "file does not exist" (ENOENT) is the legitimate TOFU first-use
+                // case; any other stat() failure (EACCES on the file or a parent directory,
+                // ENOTDIR, EIO, ...) means the file may exist but is inaccessible - continuing
+                // with an empty known-hosts set would silently bypass host key verification, so
+                // fail closed instead
+                int stat_errno = errno;
+                libssh2_knownhost_free(nh);
+                disconnectUnlocked(true);
+                xsink && xsink->raiseException("SSH2-HOSTKEY-ERROR",
+                    "the configured known_hosts file '%s' could not be accessed (%s); refusing "
+                    "to connect to avoid bypassing host key verification",
+                    known_hosts_file.c_str(), strerror(stat_errno));
+                return -1;
             }
         }
 
@@ -633,10 +681,50 @@ int SSH2Client::sshConnectUnlocked(int timeout_ms, ExceptionSink *xsink = 0) {
             return -1;
         } else if (check == LIBSSH2_KNOWNHOST_CHECK_NOTFOUND) {
             if (host_key_policy == SSH2_HOSTKEY_TOFU) {
-                // Trust On First Use: add the key and continue
-                libssh2_knownhost_addc(nh, sshhost.c_str(), nullptr, hostkey, hostkey_len, nullptr, 0, kh_type, nullptr);
+                // Trust On First Use: record the key and persist it. The key MUST be persisted -
+                // if it is not, every subsequent connection is again a first-use and therefore a
+                // fresh man-in-the-middle opportunity, so any failure to persist fails the
+                // connection closed rather than continuing with a key that will be forgotten.
+                int add_rc = libssh2_knownhost_addc(nh, sshhost.c_str(), nullptr, hostkey,
+                    hostkey_len, nullptr, 0, kh_type, nullptr);
+                if (add_rc) {
+                    libssh2_knownhost_free(nh);
+                    disconnectUnlocked(true);
+                    xsink && xsink->raiseException("SSH2-HOSTKEY-ERROR",
+                        "trust-on-first-use: could not record the host key for '%s:%d' (libssh2 "
+                        "error code %d)", sshhost.c_str(), sshport, add_rc);
+                    return -1;
+                }
+                // an empty known_hosts file is a deliberate embedder choice (e.g. Qorus, where
+                // the OS user's file must not be used): the key is trusted for this session only
                 if (!known_hosts_file.empty()) {
-                    libssh2_knownhost_writefile(nh, known_hosts_file.c_str(), LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+                    // on a fresh account the parent directory (typically ~/.ssh) may not exist
+                    // yet; create it (mode 0700) so the key can actually be written
+                    if (ensure_parent_dir(known_hosts_file.c_str())) {
+                        int dir_errno = errno;
+                        libssh2_knownhost_free(nh);
+                        disconnectUnlocked(true);
+                        xsink && xsink->raiseException("SSH2-HOSTKEY-ERROR",
+                            "trust-on-first-use: could not create the directory for the "
+                            "known_hosts file '%s' (%s); refusing to connect because the "
+                            "accepted host key could not be persisted, which would leave every "
+                            "subsequent connection vulnerable to a man-in-the-middle attack",
+                            known_hosts_file.c_str(), strerror(dir_errno));
+                        return -1;
+                    }
+                    int write_rc = libssh2_knownhost_writefile(nh, known_hosts_file.c_str(),
+                        LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+                    if (write_rc) {
+                        libssh2_knownhost_free(nh);
+                        disconnectUnlocked(true);
+                        xsink && xsink->raiseException("SSH2-HOSTKEY-ERROR",
+                            "trust-on-first-use: the host key for '%s:%d' was accepted but could "
+                            "not be written to the known_hosts file '%s' (libssh2 error code "
+                            "%d); refusing to connect because every subsequent connection would "
+                            "again be a first-use and vulnerable to a man-in-the-middle attack",
+                            sshhost.c_str(), sshport, known_hosts_file.c_str(), write_rc);
+                        return -1;
+                    }
                 }
                 printd(5, "SSH2Client::connect(): host key for '%s:%d' added to known hosts (TOFU)\n", sshhost.c_str(), sshport);
             } else {
@@ -658,6 +746,22 @@ int SSH2Client::sshConnectUnlocked(int timeout_ms, ExceptionSink *xsink = 0) {
         // LIBSSH2_KNOWNHOST_CHECK_MATCH: host key matches, continue
 
         libssh2_knownhost_free(nh);
+    }
+#else
+    // this build of the ssh2 module was compiled against a libssh2 library without the
+    // known-host API (added in libssh2 1.2), so host key verification cannot be performed at
+    // all. verify_host_key now defaults to enabled, so silently connecting here would give a
+    // false sense of security; fail closed instead. Verification can be explicitly disabled
+    // (e.g. with setVerifyHostKey(False)) to connect against such a libssh2 build.
+    if (verify_host_key) {
+        disconnectUnlocked(true);
+        xsink && xsink->raiseException("SSH2-HOSTKEY-ERROR",
+            "host key verification is enabled but this build of the ssh2 module was compiled "
+            "against a libssh2 library without the known-host API (libssh2 >= 1.2 is required "
+            "for host key verification); refusing to connect unverified - rebuild the ssh2 "
+            "module against a newer libssh2, or explicitly disable verification with "
+            "setVerifyHostKey(False)");
+        return -1;
     }
 #endif
 
@@ -1094,6 +1198,17 @@ int SSH2Client::addKnownHostLocked(const char* host, int port, ExceptionSink* xs
                     "error code %d)", known_hosts_file.c_str(), read_rc);
                 return -1;
             }
+        } else if (errno != ENOENT) {
+            // only ENOENT (the file does not yet exist) is a legitimate "create on first add"
+            // case; any other stat() failure means the file may exist but is inaccessible -
+            // proceeding would silently overwrite it (discarding or masking existing entries),
+            // so fail instead
+            int stat_errno = errno;
+            libssh2_knownhost_free(nh);
+            xsink->raiseException("SSH2-HOSTKEY-ERROR",
+                "the known_hosts file '%s' could not be accessed (%s); refusing to overwrite it",
+                known_hosts_file.c_str(), strerror(stat_errno));
+            return -1;
         }
     }
 

--- a/src/SSH2Client.h
+++ b/src/SSH2Client.h
@@ -141,6 +141,10 @@ protected:
 
     DLLLOCAL void setKeysIntern();
 
+    // sets the default known_hosts file (the local OS user's ~/.ssh/known_hosts) when filesystem
+    // access is permitted; used to enable secure host key verification by default
+    DLLLOCAL void setKnownHostsIntern();
+
     DLLLOCAL virtual void deref(ExceptionSink*);
 
     DLLLOCAL int startupUnlocked();

--- a/src/ssh2-module.cpp
+++ b/src/ssh2-module.cpp
@@ -33,9 +33,116 @@
 #include "SSH2Listener.h"
 
 #include <string.h>
+#include <strings.h>
+#include <stdlib.h>
 
 // thread-local storage for password for faked keyboard-interactive authentication
 TLKeyboardPassword keyboardPassword;
+
+// process-global ssh2 host key default configuration
+//
+// precedence (highest to lowest): explicit per-object setter (SSH2Base instance methods) >
+// process-global programmatic setter (SSH2Base::setDefault*()) > QORE_SSH2_DEFAULT_* environment
+// variable > built-in default (verification on, TOFU policy, per-OS-user ~/.ssh/known_hosts).
+//
+// the environment variables are parsed once as the baseline in ssh2_module_init(); programmatic
+// setters called later override that baseline; per-object instance setters always win as they set
+// instance state directly after construction.
+namespace {
+struct Ssh2HostKeyDefaults {
+    bool verify = true;
+    int policy = SSH2_HOSTKEY_TOFU;
+    int kh_mode = SSH2_KH_DEFAULT_AUTO;
+    std::string kh_path;
+};
+}
+static QoreThreadLock ssh2_defaults_lock;
+static Ssh2HostKeyDefaults ssh2_defaults;
+
+static bool ssh2_parse_env_bool(const char* val, bool def) {
+    if (!val || !val[0]) {
+        return def;
+    }
+    if (!strcasecmp(val, "1") || !strcasecmp(val, "true") || !strcasecmp(val, "yes")
+        || !strcasecmp(val, "on")) {
+        return true;
+    }
+    if (!strcasecmp(val, "0") || !strcasecmp(val, "false") || !strcasecmp(val, "no")
+        || !strcasecmp(val, "off")) {
+        return false;
+    }
+    return def;
+}
+
+void ssh2_init_host_key_defaults() {
+    AutoLocker al(ssh2_defaults_lock);
+
+    if (const char* v = getenv("QORE_SSH2_DEFAULT_VERIFY_HOST_KEY")) {
+        ssh2_defaults.verify = ssh2_parse_env_bool(v, ssh2_defaults.verify);
+    }
+
+    if (const char* v = getenv("QORE_SSH2_DEFAULT_HOST_KEY_POLICY")) {
+        if (!strcasecmp(v, "reject") || !strcasecmp(v, "0")) {
+            ssh2_defaults.policy = SSH2_HOSTKEY_REJECT;
+        } else if (!strcasecmp(v, "tofu") || !strcasecmp(v, "1")) {
+            ssh2_defaults.policy = SSH2_HOSTKEY_TOFU;
+        }
+    }
+
+    // QORE_SSH2_DEFAULT_KNOWN_HOSTS: unset -> AUTO (built-in per-user); set but empty -> DISABLED
+    // (no implicit known_hosts file); set to a path -> EXPLICIT (use that path)
+    if (const char* v = getenv("QORE_SSH2_DEFAULT_KNOWN_HOSTS")) {
+        if (v[0]) {
+            ssh2_defaults.kh_mode = SSH2_KH_DEFAULT_EXPLICIT;
+            ssh2_defaults.kh_path = v;
+        } else {
+            ssh2_defaults.kh_mode = SSH2_KH_DEFAULT_DISABLED;
+            ssh2_defaults.kh_path.clear();
+        }
+    }
+}
+
+bool ssh2_get_default_verify_host_key() {
+    AutoLocker al(ssh2_defaults_lock);
+    return ssh2_defaults.verify;
+}
+
+void ssh2_set_default_verify_host_key(bool verify) {
+    AutoLocker al(ssh2_defaults_lock);
+    ssh2_defaults.verify = verify;
+}
+
+int ssh2_get_default_host_key_policy() {
+    AutoLocker al(ssh2_defaults_lock);
+    return ssh2_defaults.policy;
+}
+
+int ssh2_set_default_host_key_policy(int policy) {
+    if (policy != SSH2_HOSTKEY_REJECT && policy != SSH2_HOSTKEY_TOFU) {
+        return -1;
+    }
+    AutoLocker al(ssh2_defaults_lock);
+    ssh2_defaults.policy = policy;
+    return 0;
+}
+
+int ssh2_get_default_known_hosts(std::string& path) {
+    AutoLocker al(ssh2_defaults_lock);
+    if (ssh2_defaults.kh_mode == SSH2_KH_DEFAULT_EXPLICIT) {
+        path = ssh2_defaults.kh_path;
+    }
+    return ssh2_defaults.kh_mode;
+}
+
+void ssh2_set_default_known_hosts(int mode, const char* path) {
+    AutoLocker al(ssh2_defaults_lock);
+    ssh2_defaults.kh_mode = mode;
+    if (mode == SSH2_KH_DEFAULT_EXPLICIT && path) {
+        ssh2_defaults.kh_path = path;
+    } else {
+        ssh2_defaults.kh_path.clear();
+    }
+}
 
 static QoreNamespace ssh2ns("Qore::SSH2"); // namespace
 
@@ -79,6 +186,10 @@ static void ssh2_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink) {
         xsink.raiseException("MODULE-INIT-ERROR", "the runtime version of the library is too old; got '%s', expecting minimum version '%s'", libssh2_version(0), LIBSSH2_VERSION);
         return;
     }
+
+    // parse the QORE_SSH2_DEFAULT_* environment variables into the process-global host key
+    // defaults; this is the baseline that programmatic SSH2Base::setDefault*() calls override
+    ssh2_init_host_key_defaults();
 
     // setup ssh2 error map
     ssh2_emap.insert(emap_t::value_type(LIBSSH2_ERROR_SOCKET_NONE, "LIBSSH2_ERROR_SOCKET_NONE"));

--- a/src/ssh2-module.h
+++ b/src/ssh2-module.h
@@ -73,4 +73,29 @@ DLLLOCAL extern const TypedHashDecl* hashdeclSsh2HostKeyInfo;
 #define SSH2_HOSTKEY_REJECT 0
 #define SSH2_HOSTKEY_TOFU   1
 
+// process-global default known_hosts handling modes (see ssh2-module.cpp)
+#define SSH2_KH_DEFAULT_AUTO     0   //!< built-in: the local OS user's ~/.ssh/known_hosts (filesystem-gated)
+#define SSH2_KH_DEFAULT_DISABLED 1   //!< no implicit known_hosts file is used
+#define SSH2_KH_DEFAULT_EXPLICIT 2   //!< use the explicitly-configured default path
+
+#include <string>
+
+//! parses the QORE_SSH2_DEFAULT_* environment variables into the process-global defaults; called once from ssh2_module_init()
+DLLLOCAL void ssh2_init_host_key_defaults();
+
+//! returns the process-global default for host key verification
+DLLLOCAL bool ssh2_get_default_verify_host_key();
+//! sets the process-global default for host key verification
+DLLLOCAL void ssh2_set_default_verify_host_key(bool verify);
+
+//! returns the process-global default host key policy (SSH2_HOSTKEY_REJECT or SSH2_HOSTKEY_TOFU)
+DLLLOCAL int ssh2_get_default_host_key_policy();
+//! sets the process-global default host key policy; returns 0 on success, -1 if the policy is invalid
+DLLLOCAL int ssh2_set_default_host_key_policy(int policy);
+
+//! returns the process-global default known_hosts mode; if SSH2_KH_DEFAULT_EXPLICIT, \a path is set to the configured path
+DLLLOCAL int ssh2_get_default_known_hosts(std::string& path);
+//! sets the process-global default known_hosts mode; \a path is only used when \a mode is SSH2_KH_DEFAULT_EXPLICIT
+DLLLOCAL void ssh2_set_default_known_hosts(int mode, const char* path);
+
 #endif

--- a/test/NegativeTests.qtest
+++ b/test/NegativeTests.qtest
@@ -39,6 +39,7 @@ class NegativeTests inherits QUnit::Test {
         addTestCase("Algorithm preference tests", \algorithmPreferenceTests());
         addTestCase("Banner tests", \bannerTests());
         addTestCase("Host key policy tests", \hostKeyPolicyTests());
+        addTestCase("Module default tests", \moduleDefaultsTests());
         addTestCase("Keys from data tests", \keysFromDataTests());
         addTestCase("SSH2Listener constructor tests", \listenerConstructorTests());
         addTestCase("Module constant tests", \moduleConstantTests());
@@ -384,7 +385,18 @@ class NegativeTests inherits QUnit::Test {
         # Test default: no known hosts file
         {
             SSH2Client sc("ssh://user@localhost");
-            assertNothing(sc.getKnownHostsFile());
+            *string khf = sc.getKnownHostsFile();
+            assertTrue(exists khf, "default known_hosts file must be set (secure by default)");
+            assertRegex("\\.ssh/known_hosts$", khf);
+        }
+
+        # Test default known hosts file is not set when filesystem access is not allowed
+        {
+            Program p(PO_NEW_STYLE | PO_NO_FILESYSTEM);
+            p.loadModule("ssh2");
+            p.parse("*string sub get_default_kh() { SSH2Client sc('ssh://user@localhost'); "
+                "return sc.getKnownHostsFile(); }", "no_fs_kh_test");
+            assertNothing(p.callFunction("get_default_kh"));
         }
 
         # Test set/get roundtrip
@@ -394,10 +406,10 @@ class NegativeTests inherits QUnit::Test {
             assertEq("/tmp/known_hosts", sc.getKnownHostsFile());
         }
 
-        # Test default verification disabled
+        # Test host key verification is enabled by default (secure by default)
         {
             SSH2Client sc("ssh://user@localhost");
-            assertFalse(sc.getVerifyHostKey());
+            assertTrue(sc.getVerifyHostKey());
         }
 
         # Test set/get verify roundtrip
@@ -412,12 +424,12 @@ class NegativeTests inherits QUnit::Test {
         # Test SFTPClient inherits known hosts options
         {
             SFTPClient sc("sftp://user@localhost");
-            assertNothing(sc.getKnownHostsFile());
-            assertFalse(sc.getVerifyHostKey());
-            sc.setKnownHostsFile("/tmp/kh");
-            sc.setVerifyHostKey(True);
-            assertEq("/tmp/kh", sc.getKnownHostsFile());
+            assertRegex("\\.ssh/known_hosts$", sc.getKnownHostsFile());
             assertTrue(sc.getVerifyHostKey());
+            sc.setKnownHostsFile("/tmp/kh");
+            sc.setVerifyHostKey(False);
+            assertEq("/tmp/kh", sc.getKnownHostsFile());
+            assertFalse(sc.getVerifyHostKey());
         }
 
         # Test getHostKey when not connected throws
@@ -498,10 +510,10 @@ class NegativeTests inherits QUnit::Test {
     }
 
     hostKeyPolicyTests() {
-        # Test default policy is REJECT
+        # Test default policy is TOFU (secure by default)
         {
             SSH2Client sc("ssh://user@localhost");
-            assertEq(SSH2_HOSTKEY_REJECT, sc.getHostKeyPolicy());
+            assertEq(SSH2_HOSTKEY_TOFU, sc.getHostKeyPolicy());
         }
 
         # Test set/get roundtrip
@@ -525,6 +537,110 @@ class NegativeTests inherits QUnit::Test {
         {
             assertEq(0, SSH2_HOSTKEY_REJECT);
             assertEq(1, SSH2_HOSTKEY_TOFU);
+        }
+    }
+
+    moduleDefaultsTests() {
+        # process-global defaults MUST be restored, otherwise later test cases (which assert the
+        # built-in defaults) would fail
+        on_exit {
+            SSH2Base::setDefaultVerifyHostKey(True);
+            SSH2Base::setDefaultHostKeyPolicy(SSH2_HOSTKEY_TOFU);
+            SSH2Base::setDefaultKnownHostsFile();
+        }
+
+        # built-in defaults
+        {
+            assertTrue(SSH2Base::getDefaultVerifyHostKey(), "built-in default: verify on");
+            assertEq(SSH2_HOSTKEY_TOFU, SSH2Base::getDefaultHostKeyPolicy(), "built-in default: TOFU");
+            assertNothing(SSH2Base::getDefaultKnownHostsFile(), "built-in default: AUTO (per-user)");
+        }
+
+        # setDefaultVerifyHostKey affects newly-constructed objects, not existing ones
+        {
+            SSH2Client pre("ssh://user@localhost");
+            SSH2Base::setDefaultVerifyHostKey(False);
+            assertFalse(SSH2Base::getDefaultVerifyHostKey());
+            SSH2Client post("ssh://user@localhost");
+            assertFalse(post.getVerifyHostKey(), "new object inherits global verify default");
+            assertTrue(pre.getVerifyHostKey(), "pre-existing object is unaffected");
+            SSH2Base::setDefaultVerifyHostKey(True);
+        }
+
+        # setDefaultHostKeyPolicy + invalid value
+        {
+            SSH2Base::setDefaultHostKeyPolicy(SSH2_HOSTKEY_REJECT);
+            assertEq(SSH2_HOSTKEY_REJECT, SSH2Base::getDefaultHostKeyPolicy());
+            SSH2Client sc("ssh://user@localhost");
+            assertEq(SSH2_HOSTKEY_REJECT, sc.getHostKeyPolicy(), "new object inherits global policy default");
+            assertThrows("SSH2-HOSTKEY-POLICY-ERROR", sub () {
+                SSH2Base::setDefaultHostKeyPolicy(99);
+            });
+            SSH2Base::setDefaultHostKeyPolicy(SSH2_HOSTKEY_TOFU);
+        }
+
+        # known_hosts tri-state: DISABLED -> no implicit file
+        {
+            SSH2Base::setDefaultKnownHostsFile("");
+            assertEq("", SSH2Base::getDefaultKnownHostsFile(), "DISABLED reports empty string");
+            SSH2Client sc("ssh://user@localhost");
+            assertNothing(sc.getKnownHostsFile(), "DISABLED -> object has no implicit known_hosts file");
+        }
+
+        # known_hosts tri-state: EXPLICIT -> configured path
+        {
+            SSH2Base::setDefaultKnownHostsFile("/tmp/qorus_managed_known_hosts");
+            assertEq("/tmp/qorus_managed_known_hosts", SSH2Base::getDefaultKnownHostsFile());
+            SSH2Client sc("ssh://user@localhost");
+            assertEq("/tmp/qorus_managed_known_hosts", sc.getKnownHostsFile(), "EXPLICIT -> object uses configured path");
+            SFTPClient fc("sftp://user@localhost");
+            assertEq("/tmp/qorus_managed_known_hosts", fc.getKnownHostsFile(), "EXPLICIT default also applies to SFTPClient");
+        }
+
+        # known_hosts tri-state: back to AUTO
+        {
+            SSH2Base::setDefaultKnownHostsFile();
+            assertNothing(SSH2Base::getDefaultKnownHostsFile());
+            SSH2Client sc("ssh://user@localhost");
+            assertRegex("\\.ssh/known_hosts$", sc.getKnownHostsFile(), "AUTO -> per-user ~/.ssh/known_hosts");
+        }
+
+        # process-global: a default set here is visible to objects created in another Program in
+        # the same process (binary modules are loaded once per process)
+        {
+            SSH2Base::setDefaultVerifyHostKey(False);
+            Program p(PO_NEW_STYLE);
+            p.loadModule("ssh2");
+            p.parse("bool sub get_v() { SSH2Client sc('ssh://user@localhost'); return sc.getVerifyHostKey(); }",
+                "pg_test");
+            assertFalse(p.callFunction("get_v"), "process-global default visible in another Program");
+            SSH2Base::setDefaultVerifyHostKey(True);
+        }
+
+        # environment variables parsed as the baseline (validated in a child qore process so the
+        # variables are present at module init time)
+        {
+            string scr = sprintf("/tmp/ssh2_envtest_%d.q", getpid());
+            on_exit unlink(scr);
+            {
+                File f();
+                f.open2(scr, O_CREAT | O_WRONLY | O_TRUNC, 0700);
+                f.write("%new-style\n%requires ssh2\n"
+                    "SSH2Client sc(\"ssh://user@localhost\");\n"
+                    "printf(\"%y|%d|%y|%s\\n\", sc.getVerifyHostKey(), sc.getHostKeyPolicy(), "
+                    "exists sc.getKnownHostsFile(), sc.getKnownHostsFile() ?? \"\");\n");
+            }
+
+            # verify=off, policy=reject, known_hosts disabled (empty value)
+            string out = trim(backquote(sprintf("QORE_SSH2_DEFAULT_VERIFY_HOST_KEY=0 "
+                "QORE_SSH2_DEFAULT_HOST_KEY_POLICY=reject QORE_SSH2_DEFAULT_KNOWN_HOSTS= "
+                "qore %s 2>&1", scr)));
+            assertEq("False|0|False|", out, "env vars parsed: verify off, reject, kh disabled");
+
+            # known_hosts explicit path via env; verify/policy left at built-in defaults
+            string out2 = trim(backquote(sprintf("QORE_SSH2_DEFAULT_KNOWN_HOSTS=/tmp/env_kh "
+                "qore %s 2>&1", scr)));
+            assertEq("True|1|True|/tmp/env_kh", out2, "env var parsed: explicit known_hosts path");
         }
     }
 

--- a/test/NegativeTests.qtest
+++ b/test/NegativeTests.qtest
@@ -382,12 +382,18 @@ class NegativeTests inherits QUnit::Test {
     }
 
     knownHostsOptionTests() {
-        # Test default: no known hosts file
+        # Test default known hosts file. AUTO resolution of the per-user ~/.ssh/known_hosts is
+        # compiled inside #ifdef HAVE_PWD_H, so it is only available on platforms with <pwd.h>;
+        # on Windows (no <pwd.h>) the compiled behavior is no implicit file (NOTHING).
         {
             SSH2Client sc("ssh://user@localhost");
             *string khf = sc.getKnownHostsFile();
-            assertTrue(exists khf, "default known_hosts file must be set (secure by default)");
-            assertRegex("\\.ssh/known_hosts$", khf);
+            if (PlatformOS == "Windows") {
+                assertNothing(khf, "no <pwd.h> on Windows: AUTO known_hosts is not auto-resolved");
+            } else {
+                assertTrue(exists khf, "default known_hosts file must be set (secure by default)");
+                assertRegex("\\.ssh/known_hosts$", khf);
+            }
         }
 
         # Test default known hosts file is not set when filesystem access is not allowed
@@ -424,7 +430,12 @@ class NegativeTests inherits QUnit::Test {
         # Test SFTPClient inherits known hosts options
         {
             SFTPClient sc("sftp://user@localhost");
-            assertRegex("\\.ssh/known_hosts$", sc.getKnownHostsFile());
+            # AUTO ~/.ssh/known_hosts resolution requires <pwd.h> (absent on Windows)
+            if (PlatformOS == "Windows") {
+                assertNothing(sc.getKnownHostsFile(), "no <pwd.h> on Windows: not auto-resolved");
+            } else {
+                assertRegex("\\.ssh/known_hosts$", sc.getKnownHostsFile());
+            }
             assertTrue(sc.getVerifyHostKey());
             sc.setKnownHostsFile("/tmp/kh");
             sc.setVerifyHostKey(False);
@@ -602,7 +613,12 @@ class NegativeTests inherits QUnit::Test {
             SSH2Base::setDefaultKnownHostsFile();
             assertNothing(SSH2Base::getDefaultKnownHostsFile());
             SSH2Client sc("ssh://user@localhost");
-            assertRegex("\\.ssh/known_hosts$", sc.getKnownHostsFile(), "AUTO -> per-user ~/.ssh/known_hosts");
+            # AUTO resolves the per-user ~/.ssh/known_hosts only where <pwd.h> exists
+            if (PlatformOS == "Windows") {
+                assertNothing(sc.getKnownHostsFile(), "no <pwd.h> on Windows: AUTO not resolved");
+            } else {
+                assertRegex("\\.ssh/known_hosts$", sc.getKnownHostsFile(), "AUTO -> per-user ~/.ssh/known_hosts");
+            }
         }
 
         # process-global: a default set here is visible to objects created in another Program in

--- a/test/Ssh2Client.qtest
+++ b/test/Ssh2Client.qtest
@@ -43,6 +43,7 @@ class Ssh2ClientTest inherits QUnit::Test {
         addTestCase("Host key info test", \hostKeyInfoTest());
         addTestCase("Known hosts TOFU test", \knownHostsTofuTest());
         addTestCase("Known hosts reject test", \knownHostsRejectTest());
+        addTestCase("Secure defaults and fail-closed test", \secureDefaultsAndFailClosedTest());
         addTestCase("Channel PTY resize test", \channelPtyResizeTest());
         addTestCase("Channel exit signal test", \channelExitSignalTest());
         addTestCase("Algorithm query test", \algorithmQueryTest());
@@ -233,6 +234,55 @@ class Ssh2ClientTest inherits QUnit::Test {
             sc.connect();
             assertEq(True, boolean(sc.connected()));
             sc.disconnect();
+        }
+    }
+
+    secureDefaultsAndFailClosedTest() {
+        string kh_file = sprintf("%s/ssh2_test_known_hosts_%s", tmp_location(), get_random_string(10));
+        string bad_kh = sprintf("%s/ssh2_test_unreadable_kh_%s", tmp_location(), get_random_string(10));
+        on_exit {
+            if (is_file(kh_file)) {
+                unlink(kh_file);
+            }
+            unlink(bad_kh);
+        }
+
+        # a client with no explicit host key configuration must be secure by default:
+        # verification enabled, TOFU policy; only the known_hosts path is overridden so the test
+        # does not pollute the real ~/.ssh/known_hosts file
+        {
+            SSH2Client sc(uri);
+            setPrivateKey(sc);
+            assertTrue(sc.getVerifyHostKey(), "host key verification must be enabled by default");
+            assertEq(SSH2_HOSTKEY_TOFU, sc.getHostKeyPolicy(), "default host key policy must be TOFU");
+
+            sc.setKnownHostsFile(kh_file);
+            assertFalse(is_file(kh_file), "known_hosts file must not exist before first connect");
+            sc.connect();
+            assertEq(True, boolean(sc.connected()), "secure defaults must allow first connect (TOFU)");
+            assertEq(True, is_file(kh_file), "TOFU on a non-existent known_hosts path must create the file");
+            sc.disconnect();
+        }
+
+        # an existing known_hosts file that cannot be read must fail closed (SSH2-HOSTKEY-ERROR)
+        # rather than silently connecting without host key verification; running as root bypasses
+        # filesystem permission checks, so only assert this when not root
+        if (getuid() != 0) {
+            # create the file with mode 0000 so it exists but cannot be read
+            {
+                File f();
+                f.open2(bad_kh, O_CREAT | O_WRONLY | O_TRUNC, 0000);
+                f.write("# unreadable\n");
+            }
+            assertFalse(is_readable(bad_kh), "known_hosts file must be unreadable for this check");
+
+            SSH2Client sc(uri);
+            setPrivateKey(sc);
+            sc.setKnownHostsFile(bad_kh);
+            assertThrows("SSH2-HOSTKEY-ERROR", "could not be read or parsed", sub () {
+                sc.connect();
+            });
+            assertEq(False, boolean(sc.connected()), "must not be connected after fail-closed");
         }
     }
 

--- a/test/Ssh2Client.qtest
+++ b/test/Ssh2Client.qtest
@@ -44,6 +44,8 @@ class Ssh2ClientTest inherits QUnit::Test {
         addTestCase("Known hosts TOFU test", \knownHostsTofuTest());
         addTestCase("Known hosts reject test", \knownHostsRejectTest());
         addTestCase("Secure defaults and fail-closed test", \secureDefaultsAndFailClosedTest());
+        addTestCase("Known hosts TOFU creates parent dir test", \knownHostsTofuCreatesParentDirTest());
+        addTestCase("Known hosts stat error fail-closed test", \knownHostsStatErrorFailClosedTest());
         addTestCase("Channel PTY resize test", \channelPtyResizeTest());
         addTestCase("Channel exit signal test", \channelExitSignalTest());
         addTestCase("Algorithm query test", \algorithmQueryTest());
@@ -284,6 +286,89 @@ class Ssh2ClientTest inherits QUnit::Test {
             });
             assertEq(False, boolean(sc.connected()), "must not be connected after fail-closed");
         }
+    }
+
+    knownHostsTofuCreatesParentDirTest() {
+        # F3: under TOFU the accepted host key MUST be persisted; on a fresh account the parent
+        # directory of the known_hosts file (typically ~/.ssh) may not exist yet. The module must
+        # create it (mode 0700) so the key is written - otherwise every subsequent connection is
+        # again a first-use and vulnerable to a man-in-the-middle attack.
+        string kh_dir = sprintf("%s/ssh2_test_khdir_%s", tmp_location(), get_random_string(10));
+        string kh_file = kh_dir + "/known_hosts";
+        on_exit {
+            if (is_file(kh_file)) {
+                unlink(kh_file);
+            }
+            if (is_dir(kh_dir)) {
+                rmdir(kh_dir);
+            }
+        }
+
+        assertFalse(is_dir(kh_dir), "the known_hosts parent directory must not exist before connect");
+
+        # first connection: TOFU must create the missing parent directory and persist the key
+        {
+            SSH2Client sc(uri);
+            setPrivateKey(sc);
+            sc.setKnownHostsFile(kh_file);
+            sc.setVerifyHostKey(True);
+            sc.setHostKeyPolicy(SSH2_HOSTKEY_TOFU);
+            sc.connect();
+            assertEq(True, boolean(sc.connected()), "TOFU must connect on first use");
+            sc.disconnect();
+        }
+
+        assertEq(True, is_dir(kh_dir), "TOFU must create the missing known_hosts parent directory");
+        assertEq(0700, hstat(kh_dir).mode & 0777, "the created known_hosts directory must be mode 0700");
+        assertEq(True, is_file(kh_file), "TOFU must persist the host key to the known_hosts file");
+
+        # second connection with REJECT policy: succeeds only if the key was actually persisted
+        {
+            SSH2Client sc(uri);
+            setPrivateKey(sc);
+            sc.setKnownHostsFile(kh_file);
+            sc.setVerifyHostKey(True);
+            sc.setHostKeyPolicy(SSH2_HOSTKEY_REJECT);
+            sc.connect();
+            assertEq(True, boolean(sc.connected()),
+                "persisted key must satisfy a later REJECT-policy connect");
+            sc.disconnect();
+        }
+    }
+
+    knownHostsStatErrorFailClosedTest() {
+        # F1: only ENOENT (the file genuinely does not exist) is the legitimate TOFU first-use
+        # case. If stat() on the configured known_hosts file fails for any other reason - here a
+        # parent directory with no search permission yields EACCES - the file may exist but be
+        # inaccessible, so the module must fail closed instead of silently connecting unverified.
+        # Running as root bypasses filesystem permission checks, so skip the assertion as root.
+        if (getuid() == 0) {
+            testSkip("cannot test EACCES fail-closed as root");
+        }
+
+        string kh_dir = sprintf("%s/ssh2_test_noexec_%s", tmp_location(), get_random_string(10));
+        string kh_file = kh_dir + "/known_hosts";
+        mkdir(kh_dir, 0700);
+        # drop search (execute) permission so stat() on a path inside it fails with EACCES (not
+        # ENOENT) - this is distinct from the unreadable-file case, which fails in readfile()
+        chmod(kh_dir, 0000);
+        on_exit {
+            chmod(kh_dir, 0700);
+            if (is_file(kh_file)) {
+                unlink(kh_file);
+            }
+            rmdir(kh_dir);
+        }
+
+        SSH2Client sc(uri);
+        setPrivateKey(sc);
+        sc.setKnownHostsFile(kh_file);
+        sc.setVerifyHostKey(True);
+        sc.setHostKeyPolicy(SSH2_HOSTKEY_TOFU);
+        assertThrows("SSH2-HOSTKEY-ERROR", "could not be accessed", sub () {
+            sc.connect();
+        });
+        assertEq(False, boolean(sc.connected()), "must not be connected after stat() fail-closed");
     }
 
     channelPtyResizeTest() {

--- a/test/Ssh2Connections.qtest
+++ b/test/Ssh2Connections.qtest
@@ -4,7 +4,7 @@
 %modern
 
 %requires ../qlib/Ssh2Connections.qm
-%requires ssh2 >= 1.2
+%requires ssh2 >= 2.0
 
 %requires Util
 %requires QUnit
@@ -35,6 +35,7 @@ class Ssh2ConnectionsTest inherits QUnit::Test {
 
         addTestCase("SftpConnection test", \sftpTest());
         addTestCase("Ssh2Connection test", \ssh2Test());
+        addTestCase("Scheme metadata reflects module default", \schemeMetadataTest());
 
         set_return_value(main());
     }
@@ -91,6 +92,32 @@ class Ssh2ConnectionsTest inherits QUnit::Test {
         # issue #3696: test connection serialization
         Ssh2ClientConnection conn2 = Serializable::deserialize(conn.serialize());
         assertEq(conn.url, conn2.url);
+    }
+
+    schemeMetadataTest() {
+        # restore the process-global default regardless of assertion outcome
+        on_exit SSH2Base::setDefaultVerifyHostKey(True);
+
+        SftpConnection sconn("test", "test", uri, {}, getOptions());
+        Ssh2ClientConnection cconn("test", "test", uri, {}, getOptions());
+
+        # by default the connection scheme advertises verify_host_key default_value = True
+        assertEq(True, sconn.getConnectionSchemeInfo().options.verify_host_key.default_value,
+            "SftpConnection scheme reflects secure default");
+        assertEq(True, cconn.getConnectionSchemeInfo().options.verify_host_key.default_value,
+            "Ssh2ClientConnection scheme reflects secure default");
+
+        # when an embedding application changes the module-global default, connection
+        # introspection must reflect it (issue: OS user != logical user)
+        SSH2Base::setDefaultVerifyHostKey(False);
+        assertEq(False, sconn.getConnectionSchemeInfo().options.verify_host_key.default_value,
+            "SftpConnection scheme reflects overridden module default");
+        assertEq(False, cconn.getConnectionSchemeInfo().options.verify_host_key.default_value,
+            "Ssh2ClientConnection scheme reflects overridden module default");
+
+        SSH2Base::setDefaultVerifyHostKey(True);
+        assertEq(True, sconn.getConnectionSchemeInfo().options.verify_host_key.default_value,
+            "scheme reflects restored module default");
     }
 
     private usageIntern() {


### PR DESCRIPTION
## Summary

Security audit remediation for the ssh2 module (2.0.0, unreleased), plus process-global controls so embedders such as **Qorus** (where the OS user running the process is unrelated to the logical user making connections) can change the defaults without relying on every call site.

### Security fixes
- **HIGH — host key verification off by default.** `verify_host_key` was `false` with no known_hosts, allowing trivial MITM / credential disclosure. Now secure by default: verification on, `SSH2_HOSTKEY_TOFU` policy, the local OS user's `~/.ssh/known_hosts` auto-resolved (filesystem-gated on `PO_NO_FILESYSTEM`).
- **MEDIUM — plaintext password logged.** The auth password was written to `printd` debug output during password/keyboard-interactive auth; now redacted.
- **Fail closed.** A configured known_hosts file that exists but cannot be read/parsed now raises `SSH2-HOSTKEY-ERROR` instead of silently connecting unverified (the `libssh2_knownhost_readfile` return value was ignored in both `sshConnectUnlocked` and `addKnownHostLocked`).

### Embedder support (process-global defaults)
Precedence: per-object setter > `SSH2Base::setDefault*()` > `QORE_SSH2_DEFAULT_*` env var > built-in.
- `SSH2Base::{set,get}DefaultVerifyHostKey()`, `{set,get}DefaultHostKeyPolicy()`
- `SSH2Base::{set,get}DefaultKnownHostsFile()` — tri-state: `NOTHING`=auto, `""`=disabled (no implicit file — what Qorus should call at startup), path=explicit
- `QORE_SSH2_DEFAULT_{VERIFY_HOST_KEY,HOST_KEY_POLICY,KNOWN_HOSTS}` env vars
- `Ssh2Connections.qm` scheme introspection reflects the effective global verify default; `verify_host_key` option defaults to `True` and an explicit `False` is honored

### Cleanup
- De-duplicated the `scpGet` stat→hash mapping (the `HAVE_LIBSSH2_SCP_RECV2` branch now calls `map_ssh2_sbuf_to_hash()`, removing a diverged copy and the unused-function warning)
- Fixed pre-existing `-Wreorder` warnings on the touched constructors

## Testing
- Release + debug builds: **warning-free**
- Full suite: **7 files, 50 cases, 330 assertions — all pass**
- Valgrind (`qore -b`, debug) on the affected tests: **0 bytes definitely/indirectly lost, no module-code frames** (only the known pre-existing libqore baseline noise)
- New tests: `moduleDefaultsTests` (tri-state, invalid policy, pre/post-object isolation, process-global via in-proc `Program`, env-var via child `qore`), `secureDefaultsAndFailClosedTest`, `Ssh2Connections` scheme-metadata test; stale default assertions updated

## Follow-up (out of scope for this repo)
Wiring `SSH2Base::setDefaultKnownHostsFile("")` into Qorus startup is a change in the Qorus repo; this PR provides the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)